### PR TITLE
Perf + UX improvements: hot-path caching, zero-alloc engine, settings polish

### DIFF
--- a/App/Sources/AppState.swift
+++ b/App/Sources/AppState.swift
@@ -7,7 +7,6 @@
 import Foundation
 
 extension Notification.Name {
-    static let telexSettingsChanged = Notification.Name("com.viettelex.settingsChanged")
     /// Posted by the mouse tap on any click: the caret may have moved, so any active
     /// composition must be abandoned (mirrors OpenKey's reset-on-mouse behavior).
     static let telexResetComposition = Notification.Name("com.viettelex.resetComposition")
@@ -60,7 +59,7 @@ final class AppState: @unchecked Sendable {
     /// retore). Default ON. Users who explicitly turned it off keep their choice.
     var autoRestore: Bool {
         get { defaults.object(forKey: Key.autoRestore) as? Bool ?? true }
-        set { defaults.set(newValue, forKey: Key.autoRestore); notify() }
+        set { defaults.set(newValue, forKey: Key.autoRestore) }
     }
 
     /// "Bỏ dấu tự do" (free mark placement, OpenKey term). When ON, modifier keys
@@ -70,28 +69,28 @@ final class AppState: @unchecked Sendable {
     /// ("ama"→ama, "trangw"→trangw; type "coot"/"trawng" to get the diacritic).
     var freeMarking: Bool {
         get { defaults.object(forKey: Key.freeMarking) as? Bool ?? false }
-        set { defaults.set(newValue, forKey: Key.freeMarking); notify() }
+        set { defaults.set(newValue, forKey: Key.freeMarking) }
     }
 
     /// Tone-placement style. false (default) = old style (hòa, thủy); true = modern
     /// (hoà, thuý). See `TelexEngine.modernTone`.
     var modernOrthography: Bool {
         get { defaults.object(forKey: Key.modernOrthography) as? Bool ?? false }
-        set { defaults.set(newValue, forKey: Key.modernOrthography); notify() }
+        set { defaults.set(newValue, forKey: Key.modernOrthography) }
     }
 
     /// Live spell-check: stop transforming a word mid-typing once it can't be valid
     /// Vietnamese (foreign words / URLs). Default ON. See `TelexEngine.liveSpellCheck`.
     var liveSpellCheck: Bool {
         get { defaults.object(forKey: Key.liveSpellCheck) as? Bool ?? true }
-        set { defaults.set(newValue, forKey: Key.liveSpellCheck); notify() }
+        set { defaults.set(newValue, forKey: Key.liveSpellCheck) }
     }
 
     /// Simple Telex: a standalone `w` stays literal (type `uw` for ư). Default ON.
     /// See `TelexEngine.simpleTelex`.
     var simpleTelex: Bool {
         get { defaults.object(forKey: Key.simpleTelex) as? Bool ?? true }
-        set { defaults.set(newValue, forKey: Key.simpleTelex); notify() }
+        set { defaults.set(newValue, forKey: Key.simpleTelex) }
     }
 
     // MARK: - Shortcuts (bảng gõ tắt)
@@ -102,20 +101,17 @@ final class AppState: @unchecked Sendable {
     func setShortcuts(_ dict: [String: String]) {
         shortcutsCache = dict
         defaults.set(dict, forKey: Key.shortcuts)
-        notify()
     }
 
     func upsertShortcut(key: String, value: String) {
         guard !key.isEmpty else { return }
         shortcutsCache[key] = value
         defaults.set(shortcutsCache, forKey: Key.shortcuts)
-        notify()
     }
 
     func removeShortcut(key: String) {
         shortcutsCache.removeValue(forKey: key)
         defaults.set(shortcutsCache, forKey: Key.shortcuts)
-        notify()
     }
 
     // MARK: - Learned typing strategy (in-place replacementRange vs marked text)
@@ -188,7 +184,32 @@ final class AppState: @unchecked Sendable {
         defaults.set(Array(fallbackAppsCache), forKey: Key.fallbackApps)
     }
 
-    private func notify() {
-        NotificationCenter.default.post(name: .telexSettingsChanged, object: nil)
+    /// Learned lists, for the Settings UI (Tương thích ứng dụng).
+    var learnedFallbackApps: [String] { fallbackAppsCache.sorted() }
+    var learnedInPlaceApps: [String] { probedAppsCache.sorted() }
+
+    /// Forget everything learned about apps. A bad one-shot probe (app busy during
+    /// the read-back) otherwise downgrades an app to marked text forever; this lets
+    /// the user re-probe from scratch.
+    func resetLearnedApps() {
+        fallbackAppsCache = []
+        probedAppsCache = []
+        defaults.removeObject(forKey: Key.fallbackApps)
+        defaults.removeObject(forKey: Key.probedApps)
+    }
+
+    /// Would this app type better with Accessibility granted (tap / selection-replace
+    /// / empty-reset strategies)? Membership only — ignores the current trust state.
+    func wantsAccessibility(_ bundleID: String?) -> Bool {
+        guard let id = bundleID else { return false }
+        return Self.selectionApps.contains(id) || Self.emptyResetApps.contains(id)
+            || fallbackAppsCache.contains(id)
+    }
+
+    /// One-time "grant Accessibility" prompt already shown (first focus of an app
+    /// that needs the event tap while the permission is missing).
+    var axPromptShown: Bool {
+        get { defaults.bool(forKey: "axPromptShown") }
+        set { defaults.set(newValue, forKey: "axPromptShown") }
     }
 }

--- a/App/Sources/SettingsWindow.swift
+++ b/App/Sources/SettingsWindow.swift
@@ -58,6 +58,8 @@ final class SettingsModel: ObservableObject {
     @Published var liveSpellCheck: Bool { didSet { AppState.shared.liveSpellCheck = liveSpellCheck } }
     @Published var simpleTelex: Bool { didSet { AppState.shared.simpleTelex = simpleTelex } }
     @Published var shortcuts: [ShortcutRow] = []
+    @Published var fallbackApps: [String] = []
+    @Published var inPlaceApps: [String] = []
 
     init(selected: SettingsTab) {
         selectedTab = selected
@@ -67,6 +69,12 @@ final class SettingsModel: ObservableObject {
         liveSpellCheck = AppState.shared.liveSpellCheck
         simpleTelex = AppState.shared.simpleTelex
         reloadShortcuts()
+        reloadLearnedApps()
+    }
+
+    func reloadLearnedApps() {
+        fallbackApps = AppState.shared.learnedFallbackApps
+        inPlaceApps = AppState.shared.learnedInPlaceApps
     }
 
     func reloadShortcuts() {
@@ -88,7 +96,8 @@ final class SettingsModel: ObservableObject {
     }
 }
 
-struct ShortcutRow: Identifiable { let id = UUID(); let key: String; let value: String }
+// id = key: selection survives reloads, and a row can be looked up by its key.
+struct ShortcutRow: Identifiable { var id: String { key }; let key: String; let value: String }
 
 // MARK: - Root view
 
@@ -110,6 +119,10 @@ struct SettingsView: View {
 struct GeneralTab: View {
     @EnvironmentObject var model: SettingsModel
 
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
+    }
+
     var body: some View {
         Form {
             Section("Kiểu gõ") {
@@ -129,9 +142,32 @@ struct GeneralTab: View {
                 Text("Ngừng bỏ dấu ngay khi từ không thể là tiếng Việt (google, github…) thay vì đợi hết từ.")
                     .font(.caption).foregroundStyle(.secondary)
             }
+            Section("Tương thích ứng dụng") {
+                if model.fallbackApps.isEmpty && model.inPlaceApps.isEmpty {
+                    Text("Chưa có ứng dụng nào được ghi nhớ.")
+                        .font(.caption).foregroundStyle(.secondary)
+                } else {
+                    if !model.fallbackApps.isEmpty {
+                        Text("Dùng marked text: " + model.fallbackApps.joined(separator: ", "))
+                            .font(.caption).foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                    if !model.inPlaceApps.isEmpty {
+                        Text("Gõ trực tiếp OK: " + model.inPlaceApps.joined(separator: ", "))
+                            .font(.caption).foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                }
+                Button("Đặt lại (dò lại từ đầu)") {
+                    AppState.shared.resetLearnedApps()
+                    model.reloadLearnedApps()
+                }
+                Text("VietTelex tự học cách gõ phù hợp cho từng ứng dụng. Nếu một ứng dụng gõ bị gạch chân hoặc sai, bấm Đặt lại để dò lại.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
             Section("Giới thiệu") {
                 Text("© Phil Trinh @ SenPrints")
-                Text("Version 1.0")
+                Text("Version \(appVersion)")
             }
         }
         .formStyle(.grouped)
@@ -144,10 +180,16 @@ struct ShortcutsTab: View {
     @EnvironmentObject var model: SettingsModel
     @State private var newKey = ""
     @State private var newValue = ""
+    @State private var selection: ShortcutRow.ID?
+
+    /// True when the fields hold an existing shortcut (save = update, not add).
+    private var isEditing: Bool {
+        AppState.shared.shortcuts[newKey.trimmingCharacters(in: .whitespaces)] != nil
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Table(model.shortcuts) {
+            Table(model.shortcuts, selection: $selection) {
                 TableColumn("Gõ", value: \.key)
                 TableColumn("Thành", value: \.value)
                 TableColumn("") { row in
@@ -157,15 +199,22 @@ struct ShortcutsTab: View {
                 }.width(40)
             }
             .frame(minHeight: 220)
+            .onChange(of: selection) { selected in
+                // Click a row -> load it into the fields for editing in place.
+                guard let key = selected,
+                      let value = AppState.shared.shortcuts[key] else { return }
+                newKey = key
+                newValue = value
+            }
 
             HStack {
                 TextField("gõ", text: $newKey).frame(width: 120)
                 TextField("thành", text: $newValue)
-                Button("Thêm") {
-                    model.addShortcut(key: newKey, value: newValue)
-                    newKey = ""; newValue = ""
-                }.disabled(newKey.isEmpty)
+                Button(isEditing ? "Cập nhật" : "Thêm") { save() }
+                    .disabled(newKey.trimmingCharacters(in: .whitespaces).isEmpty)
             }
+            Text("Bấm một dòng để sửa.")
+                .font(.caption).foregroundStyle(.secondary)
 
             HStack {
                 Button("Nhập từ plist…") { importPlist() }
@@ -175,16 +224,47 @@ struct ShortcutsTab: View {
         }
     }
 
+    private func save() {
+        let key = newKey.trimmingCharacters(in: .whitespaces)
+        guard !key.isEmpty else { return }
+        // Overwriting a DIFFERENT entry than the one being edited needs a confirm —
+        // otherwise a typo in the key field silently clobbers an existing shortcut.
+        if AppState.shared.shortcuts[key] != nil, selection != key {
+            let alert = NSAlert()
+            alert.messageText = "Gõ tắt “\(key)” đã tồn tại"
+            alert.informativeText = "Ghi đè giá trị hiện có?"
+            alert.addButton(withTitle: "Ghi đè")
+            alert.addButton(withTitle: "Huỷ")
+            guard alert.runModal() == .alertFirstButtonReturn else { return }
+        }
+        model.addShortcut(key: key, value: newValue)
+        newKey = ""; newValue = ""; selection = nil
+    }
+
     private func importPlist() {
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [.propertyList]
         panel.allowsMultipleSelection = false
-        guard panel.runModal() == .OK, let url = panel.url,
-              let data = try? Data(contentsOf: url),
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard let data = try? Data(contentsOf: url),
               let dict = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: String]
-        else { return }
-        AppState.shared.setShortcuts(dict)
+        else {
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = "Không đọc được file"
+            alert.informativeText = "File phải là plist dạng dictionary String → String (như file Xuất ra plist… tạo)."
+            alert.runModal()
+            return
+        }
+        // Merge (imported entries win) rather than replace, so importing a shared
+        // list never silently wipes the user's existing shortcuts.
+        let merged = AppState.shared.shortcuts.merging(dict) { _, imported in imported }
+        AppState.shared.setShortcuts(merged)
         model.reloadShortcuts()
+        let alert = NSAlert()
+        alert.messageText = "Đã nhập \(dict.count) gõ tắt"
+        alert.informativeText = "Gộp vào bảng hiện có (mục trùng lấy giá trị mới)."
+        alert.runModal()
     }
 
     private func exportPlist() {

--- a/App/Sources/TelexInputController.swift
+++ b/App/Sources/TelexInputController.swift
@@ -75,12 +75,13 @@ final class TelexInputController: IMKInputController {
         // per app when "automatically switch" is on).
 
         // Decide tap-defer by the ACTUAL frontmost app — the SAME source the tap uses
-        // (NSWorkspace) — not the IMK client id, which can be nil/stale. If the client
-        // id is nil we'd otherwise think "unknown app → in-place" and wrongly compose
-        // into a terminal the tap is handling; when the tap then leaks a physical key
-        // (a brief tapDisabled window), IMKit composes it → intermittent garbage in
-        // iTerm/Claude Code. Using the frontmost app keeps controller and tap in sync.
-        let frontID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        // (FrontmostApp cache) — not the IMK client id, which can be nil/stale. If the
+        // client id is nil we'd otherwise think "unknown app → in-place" and wrongly
+        // compose into a terminal the tap is handling; when the tap then leaks a
+        // physical key (a brief tapDisabled window), IMKit composes it → intermittent
+        // garbage in iTerm/Claude Code. Using the frontmost app keeps controller and
+        // tap in sync.
+        let frontID = FrontmostApp.shared.bundleID
         let id = AppState.shared.currentBundleID ?? frontID
 
         // Apps the CGEvent tap handles (terminals via Backspace, Chromium browsers &
@@ -307,6 +308,7 @@ final class TelexInputController: IMKInputController {
         tracking = false
         if let client = sender as? IMKTextInput {
             AppState.shared.currentBundleID = client.bundleIdentifier()
+            maybePromptAccessibility(AppState.shared.currentBundleID)
         }
         // VietTelex is the active input source now: let the terminal tap act (it must
         // stay dormant when the user switches to ABC/US). ensureRunning() also revives
@@ -385,6 +387,20 @@ final class TelexInputController: IMKInputController {
             guard let self else { return }
             if Accessibility.isTrusted { self.showDebugLog() }
             else { self.grantAccessibility() }
+        }
+    }
+
+    /// One-time gentle prompt: the user just focused an app that needs the event tap
+    /// (terminal-class / Chromium / Excel) but Accessibility is missing — exactly the
+    /// moment typing would misbehave. Otherwise the permission is only discoverable
+    /// through the input-method menu. Shown once ever (axPromptShown).
+    private func maybePromptAccessibility(_ id: String?) {
+        guard !AppState.shared.axPromptShown,
+              AppState.shared.wantsAccessibility(id),
+              !Accessibility.isTrusted else { return }
+        AppState.shared.axPromptShown = true
+        DispatchQueue.main.async { [weak self] in
+            self?.grantAccessibility()
         }
     }
 

--- a/App/Sources/TerminalTap.swift
+++ b/App/Sources/TerminalTap.swift
@@ -25,17 +25,56 @@ import ApplicationServices
 import TelexCore
 
 enum Accessibility {
+    // AXIsProcessTrusted() is an out-of-process TCC check; in Chromium apps it was
+    // hit up to twice per keystroke (usesSelectionReplace on the hot path). Cache
+    // with a short TTL — a grant/revoke shows up within ttlNs, and requestIfNeeded
+    // invalidates immediately after prompting.
+    private static var cached = false
+    private static var lastCheckNs: UInt64 = 0
+    private static let ttlNs: UInt64 = 2_000_000_000
+
     /// True when the process may create an event tap / post events. Always false in
     /// the sandboxed build — it can never be granted.
-    static var isTrusted: Bool { AXIsProcessTrusted() }
+    static var isTrusted: Bool {
+        let now = DispatchTime.now().uptimeNanoseconds
+        if lastCheckNs != 0, now &- lastCheckNs < ttlNs { return cached }
+        lastCheckNs = now
+        cached = AXIsProcessTrusted()
+        return cached
+    }
+
+    static func invalidateCache() { lastCheckNs = 0 }
 
     /// Prompt for Accessibility permission (opens System Settings). Safe when already
     /// trusted (returns true, no prompt).
     @discardableResult
     static func requestIfNeeded() -> Bool {
+        invalidateCache()
         if AXIsProcessTrusted() { return true }
         let key = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
         return AXIsProcessTrustedWithOptions([key: true] as CFDictionary)
+    }
+}
+
+/// Cached frontmost-app bundle id. `NSWorkspace.shared.frontmostApplication` is an
+/// XPC round-trip and was being called on EVERY keystroke in both the tap callback
+/// (where slowness trips tapDisabledByTimeout) and the IMKit controller. App
+/// activation is an event, not a per-key question — observe it once and read a
+/// plain property on the hot path. All access is on the main thread (the tap's run
+/// loop source and NSWorkspace notifications both live there).
+final class FrontmostApp {
+    static let shared = FrontmostApp()
+
+    private(set) var bundleID: String?
+
+    private init() {
+        bundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil, queue: .main) { [weak self] note in
+            let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+            self?.bundleID = app?.bundleIdentifier
+        }
     }
 }
 
@@ -303,7 +342,7 @@ final class TerminalTapController {
         //  - MS Office → empty-char reset (Shift+Left would select adjacent cells).
         //  - Terminals (fallbackApps) → Backspace+retype.
         //  - Anything else → the IMKit in-place path handles it (pass through).
-        let id = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        let id = FrontmostApp.shared.bundleID
         if SpotlightDetector.isVisible {
             emitMode = .selection
         } else if AppState.shared.usesSelectionReplace(id) {

--- a/App/Sources/main.swift
+++ b/App/Sources/main.swift
@@ -18,6 +18,10 @@ telexServer = IMKServer(name: connectionName, bundleIdentifier: Bundle.main.bund
 // input source. Switch to another input source (or use macOS's per-app input-source
 // memory) to type English — the OS drives everything.
 
+// Prime the frontmost-app cache (registers its NSWorkspace observer) so the per-key
+// hot paths never call NSWorkspace.frontmostApplication themselves.
+_ = FrontmostApp.shared
+
 // Terminal tap-mode: OpenKey-style CGEventTap for apps that ignore replacementRange
 // (iTerm, Terminal…). No-op unless Accessibility is granted (Developer ID build);
 // re-attempted from activateServer once permission is granted.

--- a/TelexCore/Sources/TelexCore/TelexEngine.swift
+++ b/TelexCore/Sources/TelexCore/TelexEngine.swift
@@ -8,8 +8,10 @@
 // re-parses; the raw buffer also feeds auto-restore of non-Vietnamese words.
 //
 // Note: fixed-capacity `[UInt8]`/`[UInt32]` buffers are pre-reserved (capacity 32)
-// and mutated in place. InlineArray would give a stronger zero-heap guarantee but
-// requires macOS 26; reserved arrays keep the macOS 14 deployment target.
+// and mutated in place — including the render/parse scratch buffers, which live on
+// the instance so the hot path allocates nothing per keystroke. InlineArray would
+// give a stronger zero-heap guarantee but requires macOS 26; reserved arrays keep
+// the macOS 14 deployment target.
 
 public enum TelexAction: Equatable {
     /// Not handled by the engine; let the system insert the character.
@@ -71,6 +73,14 @@ public struct TelexEngine {
     private var out: [UInt32]
     private var outCount = 0
 
+    // Scratch buffers reused by render/parse every keystroke (never allocated on
+    // the hot path). Valid only during/right after the call that filled them.
+    private var scratch: [UInt32]      // render output, diffed against `out`
+    private var letters: [LetterUnit]  // parse output
+    private var rawLetter: [Int]       // raw index -> display-letter provenance
+    private var toneKeys: [Int]        // raw indices of deferred tone/z keys
+    private var vowelIdx: [Int]        // vowel positions (tone placement)
+
     // Raw index from which keys are emitted literally because live spell-check found
     // the word can no longer be valid Vietnamese. Int.max = not disabled. Unlike
     // `markCancelled` this does NOT suppress boundary auto-restore (foreign words
@@ -87,6 +97,11 @@ public struct TelexEngine {
     public init() {
         raw = [UInt8](repeating: 0, count: Self.capacity)
         out = [UInt32](repeating: 0, count: Self.capacity)
+        scratch = [UInt32](repeating: 0, count: Self.capacity)
+        letters = [LetterUnit](repeating: LetterUnit(), count: Self.capacity)
+        rawLetter = [Int](repeating: -1, count: Self.capacity)
+        toneKeys = [Int](repeating: 0, count: Self.capacity)
+        vowelIdx = [Int](repeating: 0, count: Self.capacity)
     }
 
     public var isEmpty: Bool { rawCount == 0 }
@@ -104,28 +119,27 @@ public struct TelexEngine {
         raw[rawCount] = ascii
         rawCount += 1
 
-        var newOut = [UInt32](repeating: 0, count: Self.capacity)
         var cancelled = false
-        let newCount = render(into: &newOut, cancelled: &cancelled)
+        let newCount = render(cancelled: &cancelled)
         markCancelled = cancelled
 
         // Live spell-check: once the word can no longer be valid Vietnamese, freeze
         // transforms from the NEXT key on (current output unchanged). See disabledAtCount.
-        if liveSpellCheck, disabledAtCount == Int.max, !prefixIsValid(newOut, newCount) {
+        if liveSpellCheck, disabledAtCount == Int.max, !prefixIsValid(scratch, newCount) {
             disabledAtCount = rawCount
         }
 
         // No-transform fast path: render is exactly the previous output plus this
         // character. Let the system insert it (cheapest, no flicker).
         if newCount == outCount + 1,
-           newOut[newCount - 1] == UInt32(ascii),
-           prefixMatches(newOut, upTo: outCount) {
-            copyOut(newOut, newCount)
+           scratch[newCount - 1] == UInt32(ascii),
+           prefixMatches(scratch, upTo: outCount) {
+            copyOut(newCount)
             return .passthrough
         }
 
-        let action = diff(newOut, newCount)
-        copyOut(newOut, newCount)
+        let action = diff(scratch, newCount)
+        copyOut(newCount)
         return action
     }
 
@@ -140,10 +154,8 @@ public struct TelexEngine {
         // on the next forward key (backspace itself never adds a transform).
         disabledAtCount = Int.max
 
-        var letters = [LetterUnit](repeating: LetterUnit(), count: Self.capacity)
-        var rawLetter = [Int](repeating: -1, count: Self.capacity)
         var cancelledIgnored = false
-        let (letterCount, _, _) = parse(into: &letters, rawLetter: &rawLetter, cancelled: &cancelledIgnored)
+        let (letterCount, _, _) = parse(cancelled: &cancelledIgnored)
 
         if letterCount == 0 {
             rawCount -= 1                        // nothing on screen -> drop one key
@@ -156,12 +168,11 @@ public struct TelexEngine {
             rawCount = w
         }
 
-        var newOut = [UInt32](repeating: 0, count: Self.capacity)
         var cancelled = false
-        let newCount = render(into: &newOut, cancelled: &cancelled)
+        let newCount = render(cancelled: &cancelled)
         markCancelled = cancelled
-        let action = diff(newOut, newCount)
-        copyOut(newOut, newCount)
+        let action = diff(scratch, newCount)
+        copyOut(newCount)
         return action
     }
 
@@ -232,45 +243,43 @@ public struct TelexEngine {
     // MARK: - Rendering
 
     @inline(__always)
-    private mutating func copyOut(_ newOut: [UInt32], _ n: Int) {
-        for i in 0..<n { out[i] = newOut[i] }
+    private mutating func copyOut(_ n: Int) {
+        for i in 0..<n { out[i] = scratch[i] }
         outCount = n
     }
 
-    /// Re-parse `raw` and render composed scalars into `dest`. Returns count.
+    /// Re-parse `raw` and render composed scalars into `scratch`. Returns count.
     /// `cancelled` is set true if the parse hit an explicit diacritic-cancel gesture.
-    private func render(into dest: inout [UInt32], cancelled: inout Bool) -> Int {
-        var letters = [LetterUnit](repeating: LetterUnit(), count: Self.capacity)
-        var rawLetter = [Int](repeating: -1, count: Self.capacity)
-        let (letterCount, toneIdx, tone) = parse(into: &letters, rawLetter: &rawLetter, cancelled: &cancelled)
+    private mutating func render(cancelled: inout Bool) -> Int {
+        let (letterCount, toneIdx, tone) = parse(cancelled: &cancelled)
 
         var n = 0
         for k in 0..<letterCount {
             let u = letters[k]
             var scalar = Tables.markedScalar(base: u.base, mark: u.mark, upper: u.upper)
             if k == toneIdx { scalar = Tables.applyTone(scalar, tone) }
-            dest[n] = scalar
+            scratch[n] = scalar
             n += 1
         }
         return n
     }
 
-    /// Parse `raw` into display letters. Also records, for each raw key, the index
-    /// of the display letter it produced or modified (`rawLetter[i]`); tone / z keys
-    /// map to the toned vowel. Returns letter count, tone-target letter index, tone.
-    private func parse(into letters: inout [LetterUnit], rawLetter: inout [Int],
-                       cancelled: inout Bool) -> (count: Int, toneIdx: Int, tone: Tone) {
+    /// Parse `raw` into the `letters` scratch buffer. Also records, for each raw key,
+    /// the index of the display letter it produced or modified (`rawLetter[i]`); tone
+    /// / z keys map to the toned vowel. Returns letter count, tone-target letter
+    /// index, tone.
+    private mutating func parse(cancelled: inout Bool) -> (count: Int, toneIdx: Int, tone: Tone) {
         var letterCount = 0
         var tone: Tone = .none
-        var toneKeys = [Int](repeating: 0, count: Self.capacity)
         var toneKeyCount = 0
+        for i in 0..<rawCount { rawLetter[i] = -1 }
 
         // A word starting with 'w' is English: Vietnamese has essentially no w-initial
         // syllable, so type it literally with no diacritics ("was"→was, "write"→write).
         // An initial ư is typed "uw", not "w". Applies in both modes.
         if rawCount >= 1, lowercased(raw[0]) == UInt8(ascii: "w") {
             for k in 0..<rawCount {
-                appendLetter(&letters, &letterCount,
+                appendLetter(&letterCount,
                              base: lowercased(raw[k]), mark: .none, upper: isUpperAscii(raw[k]))
                 rawLetter[k] = k
             }
@@ -292,25 +301,25 @@ public struct TelexEngine {
             // Cancelled diacritic, OR live spell-check froze the word from here on:
             // emit every remaining key literally (no tone/mark transforms).
             if cancelled || at >= disabledAtCount {
-                appendLetter(&letters, &letterCount, base: lower, mark: .none, upper: upper)
+                appendLetter(&letterCount, base: lower, mark: .none, upper: upper)
                 rawLetter[at] = letterCount - 1
                 continue
             }
 
             // Tone keys: s f r x j
             if let t = toneForKey(lower) {
-                if hasVowel(letters, letterCount) {
+                if hasVowel(letterCount) {
                     if tone == t {
                         tone = .none // double same tone -> cancel, emit literal
                         cancelled = true
-                        appendLetter(&letters, &letterCount, base: lower, mark: .none, upper: upper)
+                        appendLetter(&letterCount, base: lower, mark: .none, upper: upper)
                         rawLetter[at] = letterCount - 1
                     } else {
                         tone = t
                         toneKeys[toneKeyCount] = at; toneKeyCount += 1
                     }
                 } else {
-                    appendLetter(&letters, &letterCount, base: lower, mark: .none, upper: upper)
+                    appendLetter(&letterCount, base: lower, mark: .none, upper: upper)
                     rawLetter[at] = letterCount - 1
                 }
                 continue
@@ -362,13 +371,13 @@ public struct TelexEngine {
                     if p.mark == .breve && p.base == UInt8(ascii: "a") {
                         letters[tIdx].mark = .none
                         cancelled = true
-                        appendLetter(&letters, &letterCount, base: UInt8(ascii: "w"), mark: .none, upper: upper)
+                        appendLetter(&letterCount, base: UInt8(ascii: "w"), mark: .none, upper: upper)
                         rawLetter[at] = letterCount - 1; continue
                     }
                     if p.mark == .horn && (p.base == UInt8(ascii: "o") || p.base == UInt8(ascii: "u")) {
                         letters[tIdx].mark = .none
                         cancelled = true
-                        appendLetter(&letters, &letterCount, base: UInt8(ascii: "w"), mark: .none, upper: upper)
+                        appendLetter(&letterCount, base: UInt8(ascii: "w"), mark: .none, upper: upper)
                         rawLetter[at] = letterCount - 1; continue
                     }
                 }
@@ -379,10 +388,10 @@ public struct TelexEngine {
                 // ("kw", "windows", "ew"); auto-restore then leaves them intact.
                 // Simple Telex disables this entirely — a lone `w` is always literal
                 // (type `uw` for ư), matching OpenKey.
-                if !simpleTelex && standaloneHornUAllowed(letters, letterCount) {
-                    appendLetter(&letters, &letterCount, base: UInt8(ascii: "u"), mark: .horn, upper: upper)
+                if !simpleTelex && standaloneHornUAllowed(letterCount) {
+                    appendLetter(&letterCount, base: UInt8(ascii: "u"), mark: .horn, upper: upper)
                 } else {
-                    appendLetter(&letters, &letterCount, base: UInt8(ascii: "w"), mark: .none, upper: upper)
+                    appendLetter(&letterCount, base: UInt8(ascii: "w"), mark: .none, upper: upper)
                 }
                 rawLetter[at] = letterCount - 1
                 continue
@@ -399,7 +408,7 @@ public struct TelexEngine {
                     if p.base == lower && p.mark == .circumflex {
                         letters[pIdx].mark = .none
                         cancelled = true
-                        appendLetter(&letters, &letterCount, base: lower, mark: .none, upper: upper)
+                        appendLetter(&letterCount, base: lower, mark: .none, upper: upper)
                         rawLetter[at] = letterCount - 1; continue
                     }
                 }
@@ -414,7 +423,7 @@ public struct TelexEngine {
                         letters[k].mark = .circumflex; rawLetter[at] = k; continue
                     }
                 }
-                appendLetter(&letters, &letterCount, base: lower, mark: .none, upper: upper)
+                appendLetter(&letterCount, base: lower, mark: .none, upper: upper)
                 rawLetter[at] = letterCount - 1
                 continue
             }
@@ -430,7 +439,7 @@ public struct TelexEngine {
                     if p.base == UInt8(ascii: "d") && p.mark == .bar {
                         letters[pIdx].mark = .none
                         cancelled = true
-                        appendLetter(&letters, &letterCount, base: UInt8(ascii: "d"), mark: .none, upper: upper)
+                        appendLetter(&letterCount, base: UInt8(ascii: "d"), mark: .none, upper: upper)
                         rawLetter[at] = letterCount - 1; continue
                     }
                 }
@@ -439,13 +448,13 @@ public struct TelexEngine {
                 if letterCount > 1, letters[0].base == UInt8(ascii: "d"), letters[0].mark == .none {
                     letters[0].mark = .bar; rawLetter[at] = 0; continue
                 }
-                appendLetter(&letters, &letterCount, base: UInt8(ascii: "d"), mark: .none, upper: upper)
+                appendLetter(&letterCount, base: UInt8(ascii: "d"), mark: .none, upper: upper)
                 rawLetter[at] = letterCount - 1
                 continue
             }
 
             // ordinary letter
-            appendLetter(&letters, &letterCount, base: lower, mark: .none, upper: upper)
+            appendLetter(&letterCount, base: lower, mark: .none, upper: upper)
             rawLetter[at] = letterCount - 1
         }
 
@@ -472,11 +481,11 @@ public struct TelexEngine {
         // Tone placement; map deferred tone/z keys onto the toned vowel (or the
         // last letter when there is no tone, so they group with it for backspace).
         var effTone = tone
-        var toneIdx = tone == .none ? -1 : toneVowelIndex(letters, letterCount)
+        var toneIdx = tone == .none ? -1 : toneVowelIndex(letterCount)
         // Stop codas (-c, -ch, -p, -t) only allow sắc (´) and nặng (.). Drop an
         // invalid huyền/hỏi/ngã (e.g. "batf" stays "bat", not "bàt").
         if toneIdx >= 0, effTone == .grave || effTone == .hook || effTone == .tilde,
-           hasStopCoda(letters, letterCount) {
+           hasStopCoda(letterCount) {
             effTone = .none
             toneIdx = -1
         }
@@ -487,8 +496,7 @@ public struct TelexEngine {
 
     // MARK: - Tone placement (old style: òa, úy)
 
-    private func toneVowelIndex(_ letters: [LetterUnit], _ count: Int) -> Int {
-        var vidx = [Int](repeating: 0, count: Self.capacity)
+    private mutating func toneVowelIndex(_ count: Int) -> Int {
         var vcount = 0
 
         var start = 0
@@ -505,7 +513,7 @@ public struct TelexEngine {
         }
 
         for k in start..<count where isVowelAscii(letters[k].base) {
-            vidx[vcount] = k
+            vowelIdx[vcount] = k
             vcount += 1
         }
         if vcount == 0 {
@@ -515,29 +523,29 @@ public struct TelexEngine {
 
         // 1) A marked vowel takes the tone (last one covers ươ -> ơ).
         var lastMarked = -1
-        for j in 0..<vcount where letters[vidx[j]].mark != .none { lastMarked = vidx[j] }
+        for j in 0..<vcount where letters[vowelIdx[j]].mark != .none { lastMarked = vowelIdx[j] }
         if lastMarked >= 0 { return lastMarked }
 
         // 2) No marked vowel.
-        if vcount == 1 { return vidx[0] }
+        if vcount == 1 { return vowelIdx[0] }
 
-        let hasCoda = vidx[vcount - 1] < (count - 1)
+        let hasCoda = vowelIdx[vcount - 1] < (count - 1)
         if vcount == 2 {
-            if hasCoda { return vidx[1] }   // closed: second vowel (toàn)
+            if hasCoda { return vowelIdx[1] }   // closed: second vowel (toàn)
             // Open nucleus. OLD style: first vowel (hóa, khỏe, thúy). MODERN style:
             // second vowel BUT only for a /w/-glide-initial diphthong (oa, oe, uy →
             // hoà, khoẻ, uý). Falling diphthongs (ua, ưa, ia, ai, oi…) keep the first
             // vowel in both styles (múa, mía, tài), so only oa/oe/uy differ.
             if modernTone {
-                let a = letters[vidx[0]].base, b = letters[vidx[1]].base
+                let a = letters[vowelIdx[0]].base, b = letters[vowelIdx[1]].base
                 let glideInitial =
                     (a == UInt8(ascii: "o") && (b == UInt8(ascii: "a") || b == UInt8(ascii: "e"))) ||
                     (a == UInt8(ascii: "u") && b == UInt8(ascii: "y"))
-                if glideInitial { return vidx[1] }
+                if glideInitial { return vowelIdx[1] }
             }
-            return vidx[0]                  // open, old style: first vowel (hóa, úy)
+            return vowelIdx[0]                  // open, old style: first vowel (hóa, úy)
         }
-        return vidx[1]                      // 3 vowels: middle (oái, ngoáy)
+        return vowelIdx[1]                      // 3 vowels: middle (oái, ngoáy)
     }
 
     // MARK: - Diffing
@@ -575,7 +583,7 @@ public struct TelexEngine {
 
     /// True if the letters typed before a standalone `w` form an onset (built from
     /// base letters, marks ignored — đ reads as "d") that can precede ư.
-    private func standaloneHornUAllowed(_ letters: [LetterUnit], _ count: Int) -> Bool {
+    private func standaloneHornUAllowed(_ count: Int) -> Bool {
         if count == 0 { return true }
         var s = String.UnicodeScalarView()
         s.reserveCapacity(count)
@@ -584,7 +592,7 @@ public struct TelexEngine {
     }
 
     @inline(__always)
-    private func hasVowel(_ letters: [LetterUnit], _ count: Int) -> Bool {
+    private func hasVowel(_ count: Int) -> Bool {
         for k in 0..<count where isVowelAscii(letters[k].base) { return true }
         return false
     }
@@ -592,7 +600,7 @@ public struct TelexEngine {
     /// Does the syllable end in a stop coda (-p, -t, -c, -ch)? Such codas only
     /// allow sắc/nặng. Only meaningful when a vowel precedes (checked by caller).
     @inline(__always)
-    private func hasStopCoda(_ letters: [LetterUnit], _ count: Int) -> Bool {
+    private func hasStopCoda(_ count: Int) -> Bool {
         guard count > 0 else { return false }
         let last = letters[count - 1].base
         if last == UInt8(ascii: "p") || last == UInt8(ascii: "t") || last == UInt8(ascii: "c") {
@@ -606,8 +614,8 @@ public struct TelexEngine {
     }
 
     @inline(__always)
-    private func appendLetter(_ letters: inout [LetterUnit], _ count: inout Int,
-                              base: UInt8, mark: Mark, upper: Bool) {
+    private mutating func appendLetter(_ count: inout Int,
+                                       base: UInt8, mark: Mark, upper: Bool) {
         guard count < Self.capacity else { return }
         letters[count] = LetterUnit(base: base, mark: mark, upper: upper)
         count += 1


### PR DESCRIPTION
## Performance
- **Frontmost-app cache** — `NSWorkspace.frontmostApplication` (an XPC round-trip) was called on every keystroke in both the IMKit controller and the CGEvent tap callback (where slowness trips `tapDisabledByTimeout`). Now a `FrontmostApp` singleton observes `didActivateApplicationNotification` and the hot paths read a plain property.
- **Accessibility trust cache** — `AXIsProcessTrusted()` was hit up to twice per key in Chromium apps; now cached with a 2s TTL, invalidated when the permission prompt runs.
- **Zero-alloc engine hot path** — `TelexEngine` allocated 4 fresh arrays per keystroke (plus one in tone placement) despite the header claiming pre-reserved buffers. All scratch buffers now live on the instance.

## UX
- **"Tương thích ứng dụng" section in Settings** — shows the learned per-app strategies (marked text vs in-place) with a reset button, so a bad one-shot probe no longer downgrades an app permanently with no recourse.
- **Shortcuts table** — click a row to edit in place; overwriting a *different* existing key asks for confirmation; plist import **merges** instead of silently replacing the whole table, and both malformed files and successful imports now show feedback.
- **One-time Accessibility prompt** — shown the first time the user focuses an app that needs the event tap (terminal-class / Chromium / Excel) while the permission is missing, instead of being discoverable only via the menu.
- **Version string** read from `CFBundleShortVersionString` instead of hardcoded "1.0".

## Cleanup
- Removed the dead `telexSettingsChanged` notification (posted by every setter, observed by nothing — settings are read per keystroke anyway).

## Verification
- `swift test`: 31/31 pass; release benchmark **0.27 µs/keystroke** over 204k keystrokes.
- `xcodebuild -configuration Release`: BUILD SUCCEEDED (after `xcodegen generate`).
- Not yet manually tested as an installed input method (needs notarize-install + logout per BUILD.md).

Per request, the "Tình trạng: OK" silent clipboard copy is left as-is (hidden feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)