### PR TITLE
gonhanh.org learnings: English-collision restore, cancel contract, Đắk/Krông, tap hardening

### DIFF
--- a/App/Sources/TerminalTap.swift
+++ b/App/Sources/TerminalTap.swift
@@ -290,12 +290,29 @@ enum FocusedFieldDetector {
 
     private static func scan() -> Bool {
         guard let focused = focusedElementForScan() else { return true }
+        // ROLE rules on the focused element itself (gonhanh's detection matrix):
+        // combo boxes and search fields carry inline autocomplete that races a
+        // backspace burst, whatever app they live in — selection-replace wins.
+        // Checked BEFORE the ancestor walk so a search box inside a web area is
+        // still treated as autocomplete-prone.
+        var roleRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(focused, kAXRoleAttribute as CFString, &roleRef) == .success,
+           let role = roleRef as? String {
+            if role == "AXComboBox" { return true }
+            if role == "AXTextField" {
+                var subRef: CFTypeRef?
+                if AXUIElementCopyAttributeValue(focused, kAXSubroleAttribute as CFString, &subRef) == .success,
+                   let sub = subRef as? String, sub == "AXSearchField" {
+                    return true
+                }
+            }
+        }
         var element = focused
         // Walk up a bounded ancestor chain. 12 hops covers real browser hierarchies
         // (web content sits many groups deep) while still bounding the AX round trips.
         for _ in 0..<12 {
             AXUIElementSetMessagingTimeout(element, 0.05)
-            var roleRef: CFTypeRef?
+            roleRef = nil
             if AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef) == .success,
                let role = roleRef as? String {
                 if role == "AXWebArea" { return false }   // page content → in-place

--- a/App/Sources/TerminalTap.swift
+++ b/App/Sources/TerminalTap.swift
@@ -801,7 +801,15 @@ final class TerminalTapController {
             if !AXIsProcessTrusted() {
                 Signposts.log.fault("watchdog: Accessibility revoked with a live tap — forcing teardown")
                 self.trustMayHaveChanged()
+                return
             }
+            // Trusted but the tap silently died: the tapDisabledByTimeout event is
+            // NOT guaranteed to arrive (a callback blocked mid-post never sees it —
+            // same field data as gonhanh's watchdog). ensureRunning is a single
+            // tapIsEnabled read when healthy; re-enables or rebuilds when not.
+            // Without this a dead tap only healed on the next activateServer
+            // (app switch) — typing in the SAME app stayed broken up to that point.
+            self.ensureRunning()
         }
         t.tolerance = 1
         RunLoop.main.add(t, forMode: .common)

--- a/AppTests/GonhanhHardeningTests.swift
+++ b/AppTests/GonhanhHardeningTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import VietTelex
+
+// App-side coverage for the gonhanh-learnings batch: remote-desktop passthrough
+// routing (item 3) and tap-lifecycle safety without Accessibility (item 2).
+final class GonhanhHardeningTests: XCTestCase {
+
+    override func tearDown() {
+        Accessibility.testTrustOverride = nil
+        super.tearDown()
+    }
+
+    func testRemoteDesktopPassthroughRouting() {
+        for id in ["com.carriez.rustdesk", "com.philandro.anydesk", "com.apple.ScreenContinuity"] {
+            XCTAssertEqual(AppState.shared.autoResolvedMode(id), .passthrough, id)
+            XCTAssertTrue(AppState.builtInPassthroughApps.contains(id), "\(id) missing from plist")
+        }
+    }
+
+    func testBundledPlistCarriesTheNewRules() {
+        // the SHIPPED resource (not just the repo file) must contain the ids
+        guard let url = Bundle(for: TelexInputController.self)
+                .url(forResource: "typing-modes", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let dict = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: String]
+        else { return XCTFail("bundled typing-modes.plist unreadable") }
+        XCTAssertEqual(dict["com.carriez.rustdesk"], "passthrough")
+        XCTAssertEqual(dict["com.philandro.anydesk"], "passthrough")
+        XCTAssertEqual(dict["com.apple.ScreenContinuity"], "passthrough")
+    }
+
+    // Watchdog/lifecycle safety: with Accessibility revoked, ensureRunning must
+    // be a no-op that never creates a tap (the watchdog calls it every 3s now —
+    // it has to be safe to call from any state).
+    func testEnsureRunningIsSafeWithoutTrust() {
+        Accessibility.testTrustOverride = false
+        let controller = TerminalTapController.shared
+        controller.ensureRunning()
+        controller.ensureRunning()          // idempotent
+        XCTAssertFalse(controller.isRunning)
+    }
+}

--- a/TelexCore/Package.swift
+++ b/TelexCore/Package.swift
@@ -6,7 +6,8 @@ let package = Package(
     platforms: [.macOS(.v13)],
     products: [
         .library(name: "TelexCore", targets: ["TelexCore"]),
-        .executable(name: "gen-lessons", targets: ["GenLessons"])
+        .executable(name: "gen-lessons", targets: ["GenLessons"]),
+        .executable(name: "gen-english", targets: ["GenEnglish"])
     ],
     targets: [
         .target(
@@ -17,6 +18,10 @@ let package = Package(
         ),
         .executableTarget(
             name: "GenLessons",
+            dependencies: ["TelexCore"]
+        ),
+        .executableTarget(
+            name: "GenEnglish",
             dependencies: ["TelexCore"]
         ),
         .testTarget(

--- a/TelexCore/Sources/GenEnglish/main.swift
+++ b/TelexCore/Sources/GenEnglish/main.swift
@@ -1,0 +1,110 @@
+// gen-english — sinh bảng TỐI GIẢN các từ tiếng Anh va chạm Telex.
+//
+// Nguyên liệu: danh sách tiếng Anh xếp theo tần suất (google-10000-english).
+// Một từ vào bảng khi VÀ CHỈ KHI hôm nay engine (cài đặt mặc định) cho ra
+// kết quả KHÁC raw ở boundary — tức đúng tập từ đang bị gõ sai ("his"→hí,
+// "off"→of, "class"→clas). Từ nào validator đã restore đúng thì không cần.
+//
+// PROTECT LIST — từ tiếng Việt mà chuỗi phím raw TRÙNG từ tiếng Anh và
+// KHÔNG có cách gõ thay thế (sẽ=sex, ơn=own, tên=teen…): tiếng Việt thắng,
+// loại khỏi bảng. Người gõ tiếng Anh chấp nhận miss các từ này.
+//
+// Chạy:  swift run gen-english <wordlist.txt> <maxWords> ../Sources/TelexCore/EnglishCollisions.swift
+import Foundation
+import TelexCore
+
+/// Từ Việt phổ biến bị trùng phím với English — không bao giờ steal.
+/// (raw English → từ Việt bị mất nếu restore)
+let protected: Set<String> = [
+    "á",    // as
+    "cả",   // car
+    "sẽ",   // sex
+    "bên",  // been
+    "ơn",   // own   (cảm ơn — ơ chỉ gõ được bằng ow)
+    "tên",  // teen
+    "tô",   // too
+    "ít",   // its
+    "lơ",   // low   (làm lơ)
+    "nơ",   // now
+    "hơ",   // how
+    "tê",   // tee
+    "rôm",  // room  (rôm rả)
+    "bõ",   // box   (bõ công)
+    "ải",   // air
+    "bả",   // bar
+    "bể",   // beer
+    "bú",   // bus
+    "lê",   // lee   (quả lê, họ Lê)
+    "mã",   // max   (mã số)
+    "môn",  // moon  (môn học)
+    "rơ",   // row   (chơi rơ)
+    "sên",  // seen  (ốc sên)
+    "sỉ",   // sir   (mua sỉ)
+    "sĩ",   // six   (bác sĩ)
+    "tã",   // tax
+    "úp",   // ups   (úp mở)
+    "rẽ",   // res   (rẽ trái)
+]
+
+/// Rác viết tắt trong corpus web (không phải từ tiếng Anh thật) — vào bảng sẽ
+/// nuốt mất cách gõ tiếng Việt (sw = sư!). Từ 2 chữ chỉ nhận whitelist.
+let junk: Set<String> = ["aa", "aaa", "ar", "ee", "es", "las", "los", "der",
+    "des", "mar", "os", "res", "ref", "rw", "sw", "nw", "usr", "var", "wa",
+    "wi", "www", "est", "ie", "il", "ny", "ok"]
+let twoLetterWhitelist: Set<String> = ["of", "if", "is", "us", "or"]
+
+let args = CommandLine.arguments
+guard args.count >= 4,
+      let content = try? String(contentsOfFile: args[1], encoding: .utf8),
+      let maxWords = Int(args[2]) else {
+    FileHandle.standardError.write("usage: gen-english <wordlist> <maxWords> <out.swift>\n".data(using: .utf8)!)
+    exit(1)
+}
+
+func commitDefault(_ word: String) -> String {
+    var e = TelexEngine()
+    e.freeMarking = true          // app defaults (1.3.x)
+    e.englishWordRestore = false  // đo hành vi validator-thuần, bảng không tự soi mình
+    for ch in word { _ = e.feed(ch) }
+    return e.commitText(autoRestore: true)
+}
+
+var kept: [String] = []
+var excluded: [(String, String)] = []
+var n = 0
+for line in content.split(separator: "\n") {
+    if n >= maxWords { break }
+    let w = line.trimmingCharacters(in: .whitespaces).lowercased()
+    guard w.count >= 2, w.count <= 12, w.allSatisfy({ $0.isASCII && $0.isLetter }) else { continue }
+    n += 1
+    let out = commitDefault(w)
+    guard out != w else { continue }
+    if junk.contains(w) { continue }
+    if w.count == 2, !twoLetterWhitelist.contains(w) { continue }
+    if protected.contains(out) { excluded.append((w, out)); continue }
+    kept.append(w)
+}
+kept.sort()
+
+var src = """
+// EnglishCollisions.swift — SINH TỰ ĐỘNG bởi gen-english, ĐỪNG SỬA TAY.
+// Từ tiếng Anh phổ biến (top-\(maxWords)) mà Telex mặc định biến thành âm tiết
+// Việt hợp lệ (validator không cứu được) — force-restore ở word boundary.
+// Đã loại các từ mà tiếng Việt thắng (sẽ=sex, ơn=own… — xem gen-english).
+// Regenerate:  swift run gen-english google-10000-english.txt \(maxWords) \
+//              Sources/TelexCore/EnglishCollisions.swift
+enum EnglishCollisions {
+    /// Sorted ascii, lowercase. ~\(kept.count) từ, tra Set ở boundary (không trên hot path).
+    static let words: Set<String> = [
+"""
+for chunk in stride(from: 0, to: kept.count, by: 8) {
+    let row = kept[chunk..<min(chunk + 8, kept.count)].map { "\"\($0)\"" }.joined(separator: ", ")
+    src += "        " + row + ",\n"
+}
+src += """
+    ]
+}
+"""
+try! src.write(toFile: args[3], atomically: true, encoding: .utf8)
+print("scanned \(n)  kept \(kept.count)  protected-out \(excluded.count)")
+for (w, o) in excluded { print("  VN wins: \(w) → \(o)") }

--- a/TelexCore/Sources/TelexCore/ClientPolicy.swift
+++ b/TelexCore/Sources/TelexCore/ClientPolicy.swift
@@ -23,6 +23,10 @@ public enum ClientPolicy {
         "com.teamviewer.TeamViewer",
         "com.realvnc.vncviewer",
         "com.nulana.remotixmac",
+        "com.carriez.rustdesk",
+        "com.philandro.anydesk",
+        // iPhone Mirroring — keystrokes forward to the phone, synthetic Unicode is meaningless there
+        "com.apple.ScreenContinuity",
     ]
 
     /// True when the built-in list marks this client as force-passthrough.

--- a/TelexCore/Sources/TelexCore/EnglishCollisions.swift
+++ b/TelexCore/Sources/TelexCore/EnglishCollisions.swift
@@ -1,0 +1,26 @@
+// EnglishCollisions.swift — SINH TỰ ĐỘNG bởi gen-english, ĐỪNG SỬA TAY.
+// Từ tiếng Anh phổ biến (top-4000) mà Telex mặc định biến thành âm tiết
+// Việt hợp lệ (validator không cứu được) — force-restore ở word boundary.
+// Đã loại các từ mà tiếng Việt thắng (sẽ=sex, ơn=own… — xem gen-english).
+// Regenerate:  swift run gen-english google-10000-english.txt 4000 //              Sources/TelexCore/EnglishCollisions.swift
+enum EnglishCollisions {
+    /// Sorted ascii, lowercase. ~131 từ, tra Set ở boundary (không trên hot path).
+    static let words: Set<String> = [        "arm", "arms", "arts", "ask", "bars", "best", "bits", "boots",
+        "born", "boxes", "cars", "cast", "chair", "char", "charts", "chosen",
+        "coast", "core", "cost", "days", "did", "does", "door", "doors",
+        "down", "gary", "gas", "gene", "genre", "gets", "gifts", "goes",
+        "guys", "hair", "has", "her", "here", "his", "hits", "horse",
+        "host", "if", "is", "kits", "last", "law", "laws", "lens",
+        "les", "list", "loans", "lose", "lost", "lots", "major", "maps",
+        "marks", "mary", "meets", "mens", "mix", "more", "most", "must",
+        "nasa", "nor", "of", "or", "pair", "para", "paris", "parks",
+        "parts", "past", "peer", "per", "pets", "photos", "pieces", "poor",
+        "porn", "porno", "ports", "post", "queen", "raw", "refer", "rest",
+        "rooms", "rose", "runs", "saw", "says", "see", "seem", "seems",
+        "sense", "sets", "sexo", "songs", "soon", "task", "teens", "term",
+        "terms", "test", "theme", "themes", "there", "these", "this", "those",
+        "thus", "tips", "tits", "town", "tree", "trees", "trust", "turn",
+        "us", "usa", "vary", "virus", "visa", "war", "wars", "won",
+        "wrong", "zero", "zoom",
+    ]
+}

--- a/TelexCore/Sources/TelexCore/SyllableValidator.swift
+++ b/TelexCore/Sources/TelexCore/SyllableValidator.swift
@@ -24,14 +24,15 @@ public enum SyllableValidator {
     static let onsets: Set<String> = [
         "", "b", "c", "ch", "d", "đ", "g", "gh", "gi", "h", "k", "kh", "l",
         "m", "n", "ng", "ngh", "nh", "p", "ph", "qu", "r", "s", "t", "th",
-        "tr", "v", "x", "z", "dz"
+        "tr", "v", "x", "z", "dz",
+        "kr",   // tên địa danh dân tộc thiểu số: Krông (Đắk Lắk)
     ]
 
     // Valid rimes = nucleus (+ coda), toneless, with marks. ~180 entries.
     static let rimes: Set<String> = {
         let list = """
-        a ac ach ai am an ang anh ao ap at au ay
-        ă ăc ăm ăn ăng ăp ăt
+        a ac ach ai am an ang anh ao ap at au ay ak
+        ă ăc ăm ăn ăng ăp ăt ăk
         â âc âm ân âng âp ât âu ây
         e ec em en eng eo ep et
         ê êch êm ên êng ênh êp êt êu
@@ -66,6 +67,7 @@ public enum SyllableValidator {
     /// (-p/-t/-c/-ch) only permit sắc/nặng; everything else permits all six.
     private static func toneMask(forRime r: String) -> UInt8 {
         let stop = r.hasSuffix("p") || r.hasSuffix("t") || r.hasSuffix("c") || r.hasSuffix("ch")
+            || r.hasSuffix("k")   // coda k (Đắk, Lắk): same stop-coda rule as c
         return stop ? (1 << Tone.acute.rawValue) | (1 << Tone.dot.rawValue) : 0b0011_1111
     }
 

--- a/TelexCore/Sources/TelexCore/TelexEngine.swift
+++ b/TelexCore/Sources/TelexCore/TelexEngine.swift
@@ -315,8 +315,17 @@ public struct TelexEngine {
     private mutating func shouldRestoreRaw() -> Bool {
         if rawIsEnglishCollision() { return true }
         let composedValid = composedIsValidSyllable()
-        if markCancelled, composedValid || rawIsAllUppercase() { return false }
+        // All-caps escape is for CONSONANT-ONLY acronyms (DDDR → DDR): a vowel in
+        // the composed text means a word, not an acronym — "OFF" must not keep "OF".
+        let acronymEscape = rawIsAllUppercase() && !renderHasVowel()
+        if markCancelled, composedValid || acronymEscape { return false }
         return forceRestoreUpperTone || rawIsEnglishException() || !composedValid
+    }
+
+    @inline(__always)
+    private func renderHasVowel() -> Bool {
+        for k in 0..<pCount where isVowelAscii(renderLetters[k].base) { return true }
+        return false
     }
 
     @inline(__always)

--- a/TelexCore/Sources/TelexCore/TelexEngine.swift
+++ b/TelexCore/Sources/TelexCore/TelexEngine.swift
@@ -67,6 +67,12 @@ public struct TelexEngine {
     /// this engine, the other Simple-Telex difference.) Preserved across `reset()`.
     public var simpleTelex = false
 
+    /// Force-restore top-frequency English words that collide with valid
+    /// Vietnamese syllables ("his"→hí) at the word boundary. Default ON.
+    /// gen-english turns this OFF to regenerate the table against the
+    /// validator-only behavior (the table must not observe itself).
+    public var englishWordRestore = true
+
     static let capacity = 32
 
     // Raw keystrokes that make up the current word (ascii, case preserved).
@@ -295,13 +301,31 @@ public struct TelexEngine {
         // Skip restore when the user cancelled a diacritic on purpose ("iss"→is).
         // Validation runs on letter classes + tone (no String); Strings are built
         // only when a restore actually happens.
-        if autoRestore, !markCancelled, outCount > 0,
-           forceRestoreUpperTone || rawIsEnglishException() || !composedIsValidSyllable() {
-            if compositionDiffersFromRaw() {
-                return .replace(backspaces: outCount, insert: rawKeystrokes)
-            }
+        if autoRestore, outCount > 0, shouldRestoreRaw(), compositionDiffersFromRaw() {
+            return .replace(backspaces: outCount, insert: rawKeystrokes)
         }
         return .none
+    }
+
+    /// Boundary restore decision, shared by both commit paths.
+    /// Order matters: the English-collision table wins over everything (even a
+    /// cancel — "off"/"OFF" restore); then a cancel keeps the composed text when
+    /// it is valid Vietnamese OR an all-caps acronym escape (DDDR → DDR);
+    /// otherwise the standard validity/exception rules decide.
+    private mutating func shouldRestoreRaw() -> Bool {
+        if rawIsEnglishCollision() { return true }
+        let composedValid = composedIsValidSyllable()
+        if markCancelled, composedValid || rawIsAllUppercase() { return false }
+        return forceRestoreUpperTone || rawIsEnglishException() || !composedValid
+    }
+
+    @inline(__always)
+    private func rawIsAllUppercase() -> Bool {
+        guard rawCount >= 2 else { return false }
+        for i in 0..<rawCount where raw[i] < UInt8(ascii: "A") || raw[i] > UInt8(ascii: "Z") {
+            return false
+        }
+        return true
     }
 
     /// Final text to commit at a word boundary, with auto-restore applied
@@ -312,8 +336,7 @@ public struct TelexEngine {
         // Overflowed: never restore to `rawKeystrokes` (only the first 32 keys) —
         // return the composed prefix unchanged; the caller keeps the rest on screen.
         if overflowed { return composed }
-        if autoRestore, !markCancelled, outCount > 0,
-           forceRestoreUpperTone || rawIsEnglishException() || !composedIsValidSyllable() {
+        if autoRestore, outCount > 0, shouldRestoreRaw() {
             return rawKeystrokes
         }
         return composed
@@ -328,6 +351,33 @@ public struct TelexEngine {
         Array("was".utf8), Array("wow".utf8),
         Array("yes".utf8),   // "ýe" slips through the validator as a syllable
     ]
+    /// Generated English-collision table (EnglishCollisions.swift, gen-english):
+    /// top-frequency English words whose default-Telex transform yields a VALID
+    /// Vietnamese syllable, so validity-based restore can't catch them
+    /// ("his"→hí, "this"→thí, "see"→sê). Boundary-only; the String is built only
+    /// after cheap byte pre-filters, never on the per-key hot path.
+    private mutating func rawIsEnglishCollision() -> Bool {
+        guard englishWordRestore else { return false }
+        guard rawCount >= 2, rawCount <= 12 else { return false }
+        guard compositionDiffersFromRaw() else { return false }   // untouched words can't collide
+        // w-entries count only when the w actually BECAME ư (full Telex) — in
+        // Simple Telex the literal-w teencode forms ("wá" = quá) must survive.
+        if (raw[0] | 0x20) == UInt8(ascii: "w") {
+            let wTransformed = pCount > 0 && renderLetters[0].base == UInt8(ascii: "u")
+                && renderLetters[0].mark == .horn
+            if !wTransformed { return false }
+        }
+        var v = String.UnicodeScalarView()
+        v.reserveCapacity(rawCount)
+        for i in 0..<rawCount {
+            var b = raw[i]
+            if b >= UInt8(ascii: "A"), b <= UInt8(ascii: "Z") { b |= 0x20 }
+            guard b >= UInt8(ascii: "a"), b <= UInt8(ascii: "z") else { return false }
+            v.append(Unicode.Scalar(b))
+        }
+        return EnglishCollisions.words.contains(String(v))
+    }
+
     private func rawIsEnglishException() -> Bool {
         guard pCount > 0 else { return false }
         // w-initiated entries apply ONLY when the w actually BECAME ư (full Telex):

--- a/TelexCore/Tests/TelexCoreTests/BoundaryTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/BoundaryTests.swift
@@ -89,13 +89,23 @@ final class BoundaryTests: XCTestCase {
         }
     }
 
-    // Cancelled-diacritic words are exempt from restore in BOTH commit paths.
-    func testCancelledWordsNotRestoredEitherPath() {
-        for (keys, kept) in [("iss", "is"), ("ass", "as"), ("messs", "mess"), ("asz", "a")] {
+    // Cancel contract (2026-07-21, gonhanh learnings): a cancelled word keeps the
+    // composed text ONLY when it is valid Vietnamese; otherwise the RAW keys come
+    // back — the user gets exactly what they pressed ("off" stays off, "ass" stays
+    // ass), instead of the old collapse that silently ate a letter ("iss"→is).
+    func testCancelledWordsFollowValidityRule() {
+        // invalid after cancel → raw restore in BOTH paths
+        for keys in ["iss", "ass", "messs", "off", "class"] {
             var b = feed(keys)
-            XCTAssertEqual(b.commitBoundary(autoRestore: true), .none, "\(keys) should not restore")
-            XCTAssertEqual(commitText(keys, restore: true), kept)
+            if case .replace(_, let insert) = b.commitBoundary(autoRestore: true) {
+                XCTAssertEqual(insert, keys, "\(keys) should restore to raw")
+            } else { XCTFail("\(keys) should restore") }
+            XCTAssertEqual(commitText(keys, restore: true), keys)
         }
+        // valid after cancel (z cleared the tone, "a" is fine) → keep composed
+        var b = feed("asz")
+        XCTAssertEqual(b.commitBoundary(autoRestore: true), .none, "asz keeps composed")
+        XCTAssertEqual(commitText("asz", restore: true), "a")
     }
 
     // Empty engine: nothing to commit.

--- a/TelexCore/Tests/TelexCoreTests/EdgeCaseTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/EdgeCaseTests.swift
@@ -88,11 +88,13 @@ final class EdgeCaseTests: XCTestCase {
 
     // Cancelled words are not auto-restored (deliberate literal gesture) — extends the
     // EngineTests cases with the horn/quad-d variants.
-    func testCancelledEdgeCasesSkipRestore() {
-        XCTAssertEqual(commit("oww"), "ow")
-        XCTAssertEqual(commit("uww"), "uw")
-        XCTAssertEqual(commit("dddd"), "ddd")
+    func testCancelledEdgeCasesRestoreRawWhenInvalid() {
+        // invalid composed after a double-key cancel → raw keys come back
+        XCTAssertEqual(commit("oww"), "oww")
+        XCTAssertEqual(commit("uww"), "uww")
+        XCTAssertEqual(commit("dddd"), "dddd")
         XCTAssertEqual(commit("bzz"), "bzz")
+
     }
 
     // MARK: - Empty / trivial inputs

--- a/TelexCore/Tests/TelexCoreTests/EngineTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/EngineTests.swift
@@ -287,19 +287,21 @@ final class EngineGoldenTests: XCTestCase {
     // gesture means "I want the literal", so "iss"→is must NOT be restored to "iss".
     // Trade-off (accepted): English double-letter words like miss/class also keep the
     // composed (shorter) form rather than restoring the raw keystrokes.
-    func testCancelledMarkSkipsRestore() {
-        XCTAssertEqual(commit("iss"), "is")     // double-s cancel -> keep, not "iss"
-        XCTAssertEqual(commit("ass"), "as")
-        XCTAssertEqual(commit("aff"), "af")     // double huyền cancel
-        XCTAssertEqual(commit("asz"), "a")      // z clears the á tone -> cancel, skip restore
-        XCTAssertEqual(commit("aaa"), "aa")     // triple a -> aa (circumflex cancel)
+    func testCancelledMarkFollowsValidityRule() {
+        // Invalid composed after cancel → the raw keys come back verbatim
+        // (English doubles survive: off/class/pass — the gonhanh 10.4 class).
+        XCTAssertEqual(commit("iss"), "iss")
+        XCTAssertEqual(commit("ass"), "ass")
+        XCTAssertEqual(commit("aff"), "aff")
+        XCTAssertEqual(commit("asz"), "a")      // z-cancel leaves valid "a" -> keep composed
+        XCTAssertEqual(commit("aaa"), "aaa")    // what you typed is what you get
 
         // After a cancel the rest of the word stays literal (English): a further tone
         // key does NOT re-apply a diacritic. "messs"→mess, not "més".
         XCTAssertEqual(compose("messs"), "mess")
         XCTAssertEqual(compose("asss"), "ass")
         XCTAssertEqual(compose("bossss"), "bosss") // b,o + s(sắc) s(cancel) s s literal
-        XCTAssertEqual(commit("messs"), "mess")
+        XCTAssertEqual(commit("messs"), "messs")   // invalid after cancel → raw
 
         // Not a cancel: a mangled word (diacritic applied, no cancel) still restores
         // to the raw keystrokes. "school" -> "schôl" (oo→ô) -> restored to "school".
@@ -493,14 +495,18 @@ final class EngineGoldenTests: XCTestCase {
             XCTAssertEqual(off.commitText(autoRestore: false), display, "off keeps VN: \(keys)")
         }
 
-        // A composed form that happens to be a valid syllable is NOT restored, even
-        // when the raw was English — rule-based can't tell "test"→"tét" (bánh tét)
-        // apart. Documents the known limitation.
+        // "test"→tét is a VALID syllable the validator can't refuse — the
+        // English-collision table (EnglishCollisions.swift) now restores it.
         var t = TelexEngine()
         for ch in "test" { _ = t.feed(ch) }
         XCTAssertEqual(t.composed, "tét")
         XCTAssertTrue(SyllableValidator.isValidSyllable("tét"))
-        XCTAssertEqual(t.commitText(autoRestore: true), "tét")
+        XCTAssertEqual(t.commitText(autoRestore: true), "test")
+        // …unless the table is switched off (gen-english measurement mode).
+        var t2 = TelexEngine()
+        t2.englishWordRestore = false
+        for ch in "test" { _ = t2.feed(ch) }
+        XCTAssertEqual(t2.commitText(autoRestore: true), "tét")
     }
 
     // C1: a trailing d converts the onset d to đ.

--- a/TelexCore/Tests/TelexCoreTests/GonhanhLearningsTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/GonhanhLearningsTests.swift
@@ -57,4 +57,83 @@ final class EnglishCollisionTests: XCTestCase {
         XCTAssertEqual(commit("Lawks"), "Lắk")
         XCTAssertEqual(commit("Kroong"), "Krông")
     }
+
+    // Coda k follows the stop-coda tone rule (sắc/nặng only, like c):
+    // toneless or huyền forms are invalid and restore to raw.
+    func testCodaKToneRule() {
+        XCTAssertEqual(commit("DDawk"), "DDawk")    // toneless ăk → invalid
+        XCTAssertEqual(commit("lawkf"), "lawkf")    // huyền on stop coda → invalid
+        XCTAssertEqual(commit("lawkj"), "lặk")      // nặng allowed
+    }
+
+    // MARK: - Collision-table mechanics (item 4)
+
+    func testCollisionRestoreIsCaseInsensitive() {
+        XCTAssertEqual(commit("His"), "His")
+        XCTAssertEqual(commit("THIS"), "THIS")
+        XCTAssertEqual(commit("Off"), "Off")
+        XCTAssertEqual(commit("OFF"), "OFF")        // dict beats the all-caps cancel escape
+    }
+
+    func testCollisionTableCanBeDisabled() {
+        var e = TelexEngine()
+        e.freeMarking = true
+        e.englishWordRestore = false
+        for ch in "his" { _ = e.feed(ch) }
+        XCTAssertEqual(e.commitText(autoRestore: true), "hí")   // validator-only behavior
+    }
+
+    func testCollisionSkipsUntransformedWords() {
+        // words the engine never touched can't be "restored" (and must not be):
+        // no transform → composed == raw → commit is a no-op either way
+        for w in ["me", "do", "go", "no", "to", "and", "the"] {
+            XCTAssertEqual(commit(w), w)
+        }
+    }
+
+    // Regression net for future `gen-english` runs: the generated table must
+    // keep the pain words, and must NEVER contain a protected/junk raw.
+    func testGeneratedTableSanity() {
+        // NOTE: off/class/pass are NOT here — the cancel contract restores them
+        // structurally, so gen-english correctly leaves them out of the table.
+        for expected in ["his", "this", "see", "test", "of", "if", "is"] {
+            XCTAssertTrue(EnglishCollisions.words.contains(expected), "table lost '\(expected)'")
+        }
+        // protected: Vietnamese wins these raw sequences (sẽ=sex, ơn=own…)
+        for banned in ["sex", "teen", "been", "own", "car", "too", "its", "as",
+                       "low", "now", "how", "room", "box", "air", "bar", "beer",
+                       "bus", "lee", "max", "moon", "seen", "sir", "six", "tax", "ups"] {
+            XCTAssertFalse(EnglishCollisions.words.contains(banned), "protected '\(banned)' leaked into the table")
+        }
+        // web-corpus junk that would eat Vietnamese typing (sw = sư)
+        for junk in ["sw", "nw", "aa", "ee", "usr", "var", "www"] {
+            XCTAssertFalse(EnglishCollisions.words.contains(junk), "junk '\(junk)' leaked into the table")
+        }
+        // minimal means minimal: a few hundred words, not a dictionary
+        XCTAssertLessThan(EnglishCollisions.words.count, 400)
+        XCTAssertGreaterThan(EnglishCollisions.words.count, 80)
+    }
+
+    // MARK: - Cancel contract (item 5)
+
+    func testCancelContractMatrix() {
+        // valid Vietnamese after cancel → composed survives
+        XCTAssertEqual(commit("asz"), "a")
+        // all-caps acronym escape → composed survives (literal DD reachable)
+        XCTAssertEqual(commit("DDDR"), "DDR")
+        // invalid + not in dict → exact raw keys come back
+        XCTAssertEqual(commit("iss"), "iss")
+        XCTAssertEqual(commit("banhss"), "banhss")   // bánh + s-cancel → invalid → raw
+        // invalid + in dict → raw keys too (same visible result, dict path)
+        XCTAssertEqual(commit("boss"), "boss")
+    }
+
+    // MARK: - Remote-desktop passthrough ids (item 3)
+
+    func testNewPassthroughBundleIDs() {
+        for id in ["com.carriez.rustdesk", "com.philandro.anydesk", "com.apple.ScreenContinuity"] {
+            XCTAssertTrue(ClientPolicy.isRemoteDesktop(id), "\(id) must be passthrough")
+        }
+        XCTAssertFalse(ClientPolicy.isRemoteDesktop("com.apple.Terminal"))
+    }
 }

--- a/TelexCore/Tests/TelexCoreTests/GonhanhLearningsTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/GonhanhLearningsTests.swift
@@ -1,0 +1,60 @@
+
+import XCTest
+@testable import TelexCore
+
+/// Items 4-6 of the gonhanh-learnings batch: English-collision restore,
+/// cancel-restore semantics, ethnic-name syllables. Golden, engine-validated.
+final class EnglishCollisionTests: XCTestCase {
+    private func commit(_ keys: String) -> String {
+        var e = TelexEngine(); e.freeMarking = true
+        for ch in keys { _ = e.feed(ch) }
+        return e.commitText(autoRestore: true)
+    }
+    private func commitSimple(_ keys: String) -> String {
+        var e = TelexEngine(); e.simpleTelex = true; e.freeMarking = true
+        for ch in keys { _ = e.feed(ch) }
+        return e.commitText(autoRestore: true)
+    }
+
+    func testCommonEnglishRestores() {
+        for w in ["his", "this", "see", "of", "if", "is", "or", "us", "has",
+                  "must", "last", "list", "most", "does", "those", "these",
+                  "there", "here", "did", "days", "test", "now"] where w != "now" {
+            XCTAssertEqual(commit(w), w, "English '\(w)' must survive")
+        }
+    }
+
+    func testCancelRestoresEnglishDoubles() {
+        // double-letter cancel used to eat one letter (off→of, class→clas)
+        for w in ["off", "office", "class", "pass", "press", "less", "boss",
+                  "address", "message", "access", "process", "business"] {
+            XCTAssertEqual(commit(w), w, "'\(w)' must keep its double letter")
+        }
+        // invalid-after-cancel restores raw even for Vietnamese-looking input:
+        // the user gets exactly the keys they pressed
+        XCTAssertEqual(commit("hoass"), "hoass")
+    }
+
+    func testVietnameseProtectedWords() {
+        // raw sequences shared with English where Vietnamese WINS (protect list)
+        XCTAssertEqual(commit("sex"), "sẽ")
+        XCTAssertEqual(commit("teen"), "tên")
+        XCTAssertEqual(commit("been"), "bên")
+        XCTAssertEqual(commit("own"), "ơn")
+        XCTAssertEqual(commit("car"), "cả")
+        XCTAssertEqual(commit("too"), "tô")
+        XCTAssertEqual(commit("its"), "ít")
+        XCTAssertEqual(commit("as"), "á")
+        XCTAssertEqual(commit("low"), "lơ")
+    }
+
+    func testTeencodeSurvivesInSimpleTelex() {
+        XCTAssertEqual(commitSimple("was"), "wá")   // w-guard: literal w = teencode
+    }
+
+    func testEthnicNameSyllables() {
+        XCTAssertEqual(commit("DDawks"), "Đắk")
+        XCTAssertEqual(commit("Lawks"), "Lắk")
+        XCTAssertEqual(commit("Kroong"), "Krông")
+    }
+}

--- a/TelexCore/Tests/TelexCoreTests/TypingMatrixTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/TypingMatrixTests.swift
@@ -51,12 +51,13 @@ final class TypingMatrixTests: XCTestCase {
     }
 
     private func compose(_ keys: String, _ configure: (inout TelexEngine) -> Void = { _ in }) -> String {
-        var e = TelexEngine(); configure(&e)
+        var e = TelexEngine(); e.englishWordRestore = false; configure(&e)
         for ch in keys { _ = e.feed(ch) }
         return e.composed
     }
     private func commit(_ keys: String) -> String {
         var e = TelexEngine()
+        e.englishWordRestore = false   // matrix tests validator behavior, not English policy
         for ch in keys { _ = e.feed(ch) }
         return e.commitText(autoRestore: true)
     }

--- a/typing-modes.plist
+++ b/typing-modes.plist
@@ -57,7 +57,8 @@
 	<key>com.macromates.TextMate</key>       <string>inPlace</string>
 	<key>net.whatsapp.WhatsApp</key>         <string>inPlace</string>
 	<key>com.viettelex.inputmethod.telex</key> <string>inPlace</string>
-	<!-- App native chuẩn NSTextView — chưa tự field-test biên, probe sẽ bắt nếu sai -->
+	<!-- Nguồn: app matrix của gonhanh.org (docs/system-architecture.md) — app
+	     native chuẩn NSTextView; chưa tự field-test biên, probe sẽ bắt nếu sai -->
 	<key>com.microsoft.Powerpoint</key>      <string>inPlace</string>
 	<key>com.apple.iWork.Pages</key>         <string>inPlace</string>
 	<key>com.apple.iWork.Numbers</key>       <string>inPlace</string>
@@ -83,7 +84,7 @@
 	<key>company.thebrowser.Browser</key>    <string>axDetect</string>
 	<key>org.mozilla.firefox</key>           <string>axDetect</string>
 
-	<!-- JetBrains IDEs — autocomplete popup nuốt backspace;
+	<!-- JetBrains IDEs — autocomplete popup nuốt backspace (nguồn: gonhanh.org);
 	     selection cần quyền Trợ năng, thiếu quyền tự rơi về marked -->
 	<key>com.jetbrains.intellij</key>        <string>selection</string>
 	<key>com.jetbrains.intellij.ce</key>     <string>selection</string>
@@ -112,5 +113,8 @@
 	<key>com.teamviewer.TeamViewer</key>     <string>passthrough</string>
 	<key>com.realvnc.vncviewer</key>         <string>passthrough</string>
 	<key>com.nulana.remotixmac</key>         <string>passthrough</string>
+	<key>com.carriez.rustdesk</key>          <string>passthrough</string>
+	<key>com.philandro.anydesk</key>         <string>passthrough</string>
+	<key>com.apple.ScreenContinuity</key>    <string>passthrough</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Từ research repo gonhanh.org (6 mục user chốt)

1. **AX messaging timeout** — đã có sẵn (50ms mọi call site), không cần đổi.
2. **Watchdog tự hồi tap chết im lặng** — watchdog 3s giờ gọi thêm \`ensureRunning()\` (sự kiện tapDisabledByTimeout không được bảo đảm deliver).
3. **Passthrough**: RustDesk, AnyDesk, iPhone Mirroring.
4. **Bảng English-collision tối giản ~131 từ (~1.5KB)** — sinh bằng \`swift run gen-english\` từ danh sách English theo tần suất, chỉ giữ từ mà validator không cứu được (his→hí, this→thí, see→sê, test→tét). Protect-list 27 từ Việt thắng khi trùng phím (sẽ=sex, ơn=own, tên=teen, cả=car, sĩ=six, môn=moon…), lọc rác viết tắt (sw ≠ ăn mất "sư").
5. **Contract cancel mới**: hủy dấu giữ composed CHỈ khi là tiếng Việt hợp lệ hoặc acronym toàn hoa (DDDR→DDR); còn lại trả đúng phím thô — off/class/pass/office/business giữ đủ chữ đôi, aaa ra aaa.
6. **Đắk/Lắk/Krông**: onset \`kr\` + coda \`k\` (luật thanh như coda c).

## Test
- 125/125 engine tests (contract cũ về cancel được cập nhật có chủ đích — xem BoundaryTests/EdgeCaseTests/EngineTests)
- ZeroAllocation + KeystrokePerf: 0.108µs/keystroke (ceiling 0.40)
- 24/24 app tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)