### PR TITLE
learn: browser-language auto-detect (default vi)

### DIFF
--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -439,7 +439,18 @@
   }
   var sel = document.getElementById('langSel');
   sel.innerHTML = LANGS.map(function (l) { return '<option value="' + l[0] + '">🌐 ' + l[1] + '</option>'; }).join('');
-  var lang = state().lang;
+  var st0 = state();
+  var lang = st0.lang;
+  if (!st0.langChosen) {
+    // first visit: browser preferred language if supported, else Vietnamese
+    var prefs = (navigator.languages && navigator.languages.length)
+      ? navigator.languages : [navigator.language || ''];
+    lang = 'vi';
+    for (var i = 0; i < prefs.length; i++) {
+      var c = String(prefs[i]).slice(0, 2).toLowerCase();
+      if (LANGS.some(function (l) { return l[0] === c; })) { lang = c; break; }
+    }
+  }
   if (!LANGS.some(function (l) { return l[0] === lang; })) lang = 'vi';
   sel.value = lang;
   setLang(lang);

--- a/docs/learn/learn.js
+++ b/docs/learn/learn.js
@@ -7,6 +7,16 @@
 
 // ── Progress store ──────────────────────────────────────────────────────────
 var store = load();
+function detectBrowserLang() {
+  var supported = ['vi', 'en', 'fr', 'de', 'ko', 'ja', 'zh', 'km'];
+  var prefs = (navigator.languages && navigator.languages.length)
+    ? navigator.languages : [navigator.language || ''];
+  for (var i = 0; i < prefs.length; i++) {
+    var code = String(prefs[i]).slice(0, 2).toLowerCase();
+    if (supported.indexOf(code) >= 0) return code;
+  }
+  return 'vi';
+}
 function load() {
   var s;
   try { s = JSON.parse(localStorage.getItem('vtlearn') || 'null'); } catch (e) { s = null; }
@@ -18,7 +28,10 @@ function load() {
   if (s.track === undefined) s.track = null;
   if (s.autoSpeak === undefined) s.autoSpeak = false;
   if (s.showArt === undefined) s.showArt = true;
-  if (!s.langChosen) { s.lang = 'vi'; }
+  // First visit (no explicit choice): follow the browser's preferred language
+  // if we have it; Vietnamese otherwise. A manual 🌐 pick sets langChosen and
+  // wins forever after.
+  if (!s.langChosen) { s.lang = detectBrowserLang(); }
   if (!s.lang) s.lang = 'vi';
   if (['vi','en','fr','de','ko','ja','zh','km'].indexOf(s.lang) < 0) s.lang = 'vi';
   return s;


### PR DESCRIPTION
First visit follows navigator.languages (8 supported codes), fallback Tiếng Việt; manual pick persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)