### PR TITLE
fix: stale Accessibility detection + stop resetting the grant on install

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -2,3 +2,11 @@
    stay empty: any lookup misses and falls back to the key (= English). It exists
    so an explicit "English" UI-language pick resolves to en.lproj even on a
    Vietnamese-language system (VTLocalized loads this bundle by name). */
+
+"Status: Permission stale — click to fix" = "⚠️ Accessibility permission stuck — click to fix";
+
+"Stale permission title" = "Accessibility permission is stuck after an update";
+
+"Stale permission body" = "macOS lists VietTelex as allowed but refuses the event tap — this can happen when an updated, re-signed build sits under an old grant.\n\nOne-time fix:\n1. Open System Settings → Privacy & Security → Accessibility\n2. Select VietTelex and press − to REMOVE it\n3. Press + and add VietTelex back (~/Library/Input Methods)\n4. Switch the keyboard to ABC and back to VietTelex";
+
+"Open Accessibility Settings" = "Open Accessibility Settings";

--- a/App/Resources/vi.lproj/Localizable.strings
+++ b/App/Resources/vi.lproj/Localizable.strings
@@ -140,3 +140,11 @@
 "You can download the update from the releases page. This check ran because weekly update checks are enabled in Settings." = "Bạn có thể tải bản mới từ trang releases. Lần kiểm tra này chạy vì bạn đã bật tự kiểm tra hàng tuần trong Cài đặt.";
 "Later" = "Để sau";
 "Forget this app (pin + learned data)" = "Quên app này (xoá ép tay + dữ liệu đã học)";
+
+"Status: Permission stale — click to fix" = "⚠️ Quyền trợ năng bị kẹt — bấm để sửa";
+
+"Stale permission title" = "Quyền Trợ năng bị kẹt sau khi cập nhật";
+
+"Stale permission body" = "macOS đang liệt kê VietTelex là được phép, nhưng từ chối cấp event tap — thường xảy ra khi bản cập nhật được ký lại nằm dưới quyền cũ.\n\nCách sửa (một lần):\n1. Mở System Settings → Privacy & Security → Accessibility\n2. Chọn VietTelex, bấm nút − để XÓA khỏi danh sách\n3. Bấm + và thêm lại VietTelex (trong ~/Library/Input Methods)\n4. Chuyển bàn phím qua ABC rồi quay lại VietTelex";
+
+"Open Accessibility Settings" = "Mở cài đặt Trợ năng";

--- a/App/Sources/TelexInputController.swift
+++ b/App/Sources/TelexInputController.swift
@@ -824,9 +824,17 @@ final class TelexInputController: IMKInputController {
         // menus. Strip it (and any trailing separator) each time the menu opens.
         menu.delegate = self
 
-        // Status first. OK when Accessibility is granted (terminal tap works), else
-        // missing. No checkmark. Click → grant-permission pane if missing, else a debug log.
-        let status = NSMenuItem(title: Accessibility.isTrusted ? VTLocalized("Status: OK") : VTLocalized("Status: Permission needed"),
+        // Status first. Three states: OK / permission missing / permission STALE
+        // (trusted but the tap was refused — needs a remove+re-add, see TerminalTap).
+        let statusTitle: String
+        if !Accessibility.isTrusted {
+            statusTitle = VTLocalized("Status: Permission needed")
+        } else if TerminalTapController.shared.trustLooksStale {
+            statusTitle = VTLocalized("Status: Permission stale — click to fix")
+        } else {
+            statusTitle = VTLocalized("Status: OK")
+        }
+        let status = NSMenuItem(title: statusTitle,
                                 action: #selector(showStatus(_:)), keyEquivalent: "")
         status.target = self
         menu.addItem(status)
@@ -852,8 +860,25 @@ final class TelexInputController: IMKInputController {
         // makes it appear reliably.
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            if Accessibility.isTrusted { self.showDebugLog() }
-            else { self.grantAccessibility() }
+            if !Accessibility.isTrusted { self.grantAccessibility() }
+            else if TerminalTapController.shared.trustLooksStale { self.showStaleTrustRepair() }
+            else { self.showDebugLog() }
+        }
+    }
+
+    /// Stale-grant repair: macOS lists VietTelex as allowed but refuses the tap
+    /// (typical after a re-signed binary lands under an old grant). The ONLY fix
+    /// is user-side: remove the entry and add it back. Walk them through it.
+    @objc private func showStaleTrustRepair() {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = VTLocalized("Stale permission title")
+        alert.informativeText = VTLocalized("Stale permission body")
+        alert.addButton(withTitle: VTLocalized("Open Accessibility Settings"))
+        alert.addButton(withTitle: VTLocalized("Close"))
+        if alert.runModal() == .alertFirstButtonReturn,
+           let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+            NSWorkspace.shared.open(url)
         }
     }
 

--- a/App/Sources/TerminalTap.swift
+++ b/App/Sources/TerminalTap.swift
@@ -858,6 +858,13 @@ final class TerminalTapController {
     /// thread is event-driven (parked in mach_msg, zero CPU when idle) — it is the
     /// tap's equivalent of the main run loop, not a polling worker, so it does not
     /// violate the "no persistent background work" rule in DESIGN.md.
+    /// TRUE when the last tap-create attempt failed WHILE AXIsProcessTrusted said
+    /// yes — the classic stale TCC grant after a re-signed upgrade: the checkbox
+    /// looks on, but the system refuses the tap. Cleared the moment a tap is
+    /// created. The menu turns this into a self-serve repair instruction
+    /// (remove + re-add in Accessibility) instead of silently typing English.
+    private(set) var trustLooksStale = false
+
     func start() {
         guard stateLock.withLock({ tap == nil }), Accessibility.isTrusted else { return }
         let mask = CGEventMask((1 << CGEventType.keyDown.rawValue)
@@ -872,7 +879,15 @@ final class TerminalTapController {
                 return me.handle(type: type, event: event)
             },
             userInfo: Unmanaged.passUnretained(self).toOpaque()
-        ) else { return }
+        ) else {
+            // Trusted but the system refused the tap → stale grant (field case
+            // 2026-07-22: dev re-sign; can also follow unusual upgrade paths).
+            trustLooksStale = true
+            Signposts.log.fault("tap create FAILED while trusted — stale Accessibility grant; remove + re-add VietTelex in System Settings")
+            DebugLog.log("tap create failed while trusted → stale TCC grant")
+            return
+        }
+        trustLooksStale = false
 
         let src = CFMachPortCreateRunLoopSource(nil, tap, 0)
         // Park the source on the dedicated thread's run loop. Wait (bounded) for the

--- a/Scripts/notarize-install.sh
+++ b/Scripts/notarize-install.sh
@@ -57,12 +57,14 @@ rm -rf "$DEST"
 /usr/bin/ditto "$APP" "$DEST"
 /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "$DEST"
 spctl -a -t exec -vv "$DEST" 2>&1 | head -2
-# A re-signed build makes the old Accessibility grant STALE: AXIsProcessTrusted()
-# still returns true but CGEvent.post is silently dropped -> letters type but no
-# diacritics in tap-mode apps (see MACOS_IME_NOTES.md). Reset so the user re-grants.
-tccutil reset Accessibility com.viettelex.inputmethod.telex >/dev/null 2>&1 || true
+# DO NOT blanket-reset the Accessibility grant here (it used to, forcing a
+# re-grant on EVERY install). The designated requirement is identity-based
+# (identifier + team), so a same-identity re-sign normally keeps the grant
+# valid. When macOS does wedge the grant anyway, the app now DETECTS it
+# (trusted but tap-create refused) and walks the user through remove+re-add
+# via the menu status line — see TerminalTapController.trustLooksStale.
 pkill -x VietTelex 2>/dev/null || true
 
 echo "Done. Log out / log in ONCE (first install only), then add it: Keyboard → Input Sources → + → Vietnamese → Tiếng Việt (VietTelex)."
-echo "NOTE: Accessibility grant was reset (stale after re-sign) — re-enable VietTelex in"
-echo "System Settings → Privacy & Security → Accessibility for Terminal/Chromium typing."
+echo "If Terminal/Chromium typing stops after this install, the IME menu will show"
+echo "'Quyền trợ năng bị kẹt' with one-click repair instructions."


### PR DESCRIPTION
Không còn tccutil reset mỗi lần cài; app tự phát hiện grant kẹt (trusted nhưng tap bị từ chối) và hướng dẫn user sửa qua menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)