### PR TITLE
feat: đ-initial abbreviations (đ, đm, đc…)

### DIFF
--- a/TelexCore/Sources/TelexCore/TelexEngine.swift
+++ b/TelexCore/Sources/TelexCore/TelexEngine.swift
@@ -412,13 +412,20 @@ public struct TelexEngine {
     }
 
     private mutating func composedIsValidSyllable() -> Bool {
-        // Accepted ABBREVIATION, not a real syllable: "đc" (= được, chat shorthand)
-        // survives auto-restore — typing "ddc" keeps đc instead of reverting to raw
-        // (user decision 2026-07-21). Zero-alloc direct compare, tone-less only.
-        if pCount == 2, lastEffTone == .none,
-           renderLetters[0].base == UInt8(ascii: "d"), renderLetters[0].mark == .bar,
-           renderLetters[1].base == UInt8(ascii: "c"), renderLetters[1].mark == .none {
-            return true
+        // Đ-initial ABBREVIATIONS (chat shorthand), not real syllables: đ, đc, đm,
+        // đk, đkm… survive auto-restore — typing "ddm" keeps đm instead of
+        // reverting to raw (generalized from the đc whitelist, user decision
+        // 2026-07-22). Shape: leading đ (from dd) + ZERO or more bare consonants,
+        // no tone. Vowelled words (đi, đau) take the normal validation path;
+        // a literal lowercase "dd…" remains reachable via the ddd cancel.
+        if pCount >= 1, lastEffTone == .none,
+           renderLetters[0].base == UInt8(ascii: "d"), renderLetters[0].mark == .bar {
+            var bareConsonantsOnly = true
+            for k in 1..<pCount {
+                let l = renderLetters[k]
+                if l.mark != .none || isVowelAscii(l.base) { bareConsonantsOnly = false; break }
+            }
+            if bareConsonantsOnly { return true }
         }
         // ALL-CAPS abbreviation whose only transform is DD→Đ ("ĐSQ" = Đại Sứ Quán,
         // "ĐHQG"…): the doubled D was deliberate, restoring to "DDSQ" is strictly

--- a/TelexCore/Tests/TelexCoreTests/EngineTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/EngineTests.swift
@@ -166,8 +166,11 @@ final class EngineGoldenTests: XCTestCase {
         XCTAssertEqual(commit("DDN"), "ĐN")        // Đà Nẵng
         // escape hatch: the double-key cancel still yields a literal DD
         XCTAssertEqual(commit("DDDR"), "DDR")
-        // lowercase invalid words keep restoring
-        XCTAssertEqual(commit("ddsq"), "ddsq")
+        // lowercase đ+consonants is now an accepted abbreviation (2026-07-22)…
+        XCTAssertEqual(commit("ddsq"), "đsq")
+        // …but a vowel after the consonants exits the abbreviation rule and the
+        // normal validation restores the invalid word
+        XCTAssertEqual(commit("ddsqa"), "ddsqa")
         // vowel marks in caps are NOT covered by the acronym rule; "Â" survives
         // because the validator already accepts it as a syllable (pre-existing)
         XCTAssertEqual(commit("AA"), "Â")
@@ -176,8 +179,9 @@ final class EngineGoldenTests: XCTestCase {
     func testDcAbbreviationSurvivesAutoRestore() {
         XCTAssertEqual(commit("ddc"), "đc")
         XCTAssertEqual(compose("ddc"), "đc")
-        // Tone on it is NOT whitelisted → restores raw.
-        XCTAssertEqual(commit("ddcs"), "ddcs")
+        // s here is a literal consonant (no vowel to tone) → still đ+consonants,
+        // covered by the generalized abbreviation rule (2026-07-22)
+        XCTAssertEqual(commit("ddcs"), "đcs")
     }
 
     // Word-initial standalone w → ư belongs to FULL Telex (Simple Telex off) —

--- a/TelexCore/Tests/TelexCoreTests/GonhanhLearningsTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/GonhanhLearningsTests.swift
@@ -51,6 +51,20 @@ final class EnglishCollisionTests: XCTestCase {
         XCTAssertEqual(commitSimple("was"), "wá")   // w-guard: literal w = teencode
     }
 
+    // Đ-initial chat abbreviations survive auto-restore (đ, đm, đc, đkm…).
+    func testDdAbbreviations() {
+        XCTAssertEqual(commit("dd"), "đ")
+        XCTAssertEqual(commit("ddc"), "đc")
+        XCTAssertEqual(commit("ddm"), "đm")
+        XCTAssertEqual(commit("ddkm"), "đkm")
+        XCTAssertEqual(commit("Ddm"), "Đm")
+        // vowelled words keep the normal path (unchanged behavior)
+        XCTAssertEqual(commit("ddi"), "đi")
+        XCTAssertEqual(commit("ddieen"), "điên")
+        // literal lowercase dd stays reachable via the cancel
+        XCTAssertEqual(commit("ddd"), "dd")
+    }
+
     func testEthnicNameSyllables() {
         XCTAssertEqual(commit("DDawks"), "Đắk")
         XCTAssertEqual(commit("Lawks"), "Lắk")


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)