### PR TITLE
About: nút 'Học gõ Telex' trong tab Giới thiệu

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -26,5 +26,7 @@
 "Restart input method" = "Restart input method";
 
 "Open releases page" = "Open releases page";
+
+"Learn Telex typing" = "🎓 Learn Telex typing";
 \n"Supported formats: plist/XML, JSON, YAML, or one key:value per line (GõNhanh, EVKey…)." = "Supported formats: plist/XML, JSON, YAML, or one key:value per line (GõNhanh, EVKey…).";\n
 "Export to YAML…" = "Export to YAML…";

--- a/App/Resources/vi.lproj/Localizable.strings
+++ b/App/Resources/vi.lproj/Localizable.strings
@@ -38,6 +38,7 @@
 
 /* About tab */
 "Version %@ · %@" = "Version %@ ngày %@";
+"Learn Telex typing" = "🎓 Học gõ Telex";
 "Check for updates" = "Kiểm tra cập nhật";
 "Download update…" = "Tải bản mới…";
 "You’re up to date (%@)." = "Đã là bản mới nhất (%@).";

--- a/App/Sources/SettingsWindow.swift
+++ b/App/Sources/SettingsWindow.swift
@@ -688,6 +688,14 @@ struct AboutTab: View {
                 .foregroundStyle(.secondary)
             Link("Website", destination: URL(string: "https://ptrinh.github.io/viettelex/")!)
 
+            // Opens the browser-based Telex tutor (kept out of the app itself to
+            // stay minimal — see docs/learn).
+            Button(model.loc("Learn Telex typing")) {
+                NSWorkspace.shared.open(URL(string: "https://ptrinh.github.io/viettelex/learn/")!)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.top, 4)
+
             // Manual update check — the only thing that touches the network, and
             // only on this click (see Updater.swift).
             VStack(spacing: 4) {


### PR DESCRIPTION
Thêm nút **🎓 Học gõ Telex** trong tab Giới thiệu của app macOS, ngay **trên** nút Kiểm tra cập nhật. Bấm vào mở https://ptrinh.github.io/viettelex/learn/ trên trình duyệt — giữ app tối giản, phần học nằm ở web.

Có bản dịch VI + EN. Build sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019v1AVYDEzBiX6T7aiUErK1