### PR TITLE
Landing i18n: dịch nốt nav, cards, footer, sandbox, cheat tiles

### DIFF
--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -75,6 +75,8 @@
   .btn { display: inline-block; padding: 14px 26px; border-radius: 12px; font-weight: 700; text-decoration: none; font-size: 1rem; }
   .btn-primary { background: var(--red-bright); color: #fff; box-shadow: 0 6px 20px rgba(194,39,39,.35); }
   .btn-primary:hover { background: #d63030; }
+  .btn-learn { background: rgba(212,169,74,.14); border: 1px solid rgba(212,169,74,.55); color: var(--gold, #d4a94a); }
+  .btn-learn:hover { background: rgba(212,169,74,.24); }
   .brew { display: flex; align-items: center; gap: 10px; background: rgba(0,0,0,.35); border: 1px solid rgba(255,255,255,.14); border-radius: 12px; padding: 12px 16px; font-family: var(--mono); font-size: .84rem; color: #d8dce8; cursor: pointer; }
   .brew:hover { border-color: rgba(255,255,255,.3); }
   .brew .copied { color: var(--gold); font-family: var(--sans); font-size: .78rem; }
@@ -158,7 +160,6 @@
     <div class="cta-row" style="margin-top:26px">
       <a class="btn btn-learn" href="../learn/">🎓 Learn Telex — free, with games</a>
     </div>
-    <p class="meta">Free · Open source (MIT) · Notarized by Apple · macOS 14+</p>
   </div>
 </header>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -160,7 +160,6 @@
     <div class="cta-row" style="margin-top:26px">
       <a class="btn btn-learn" href="learn/">🎓 Học gõ Telex — miễn phí, có trò chơi</a>
     </div>
-    <p class="meta">Miễn phí · Mã nguồn mở (MIT) · Đã notarized bởi Apple · macOS 14+</p>
   </div>
 </header>
 

--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -169,8 +169,8 @@
     <div class="field" id="sandbox" tabindex="0" role="textbox" aria-label="Ô gõ thử Telex"></div>
     <div class="keysline" id="sandboxKeys"></div>
     <div class="tools">
-      <button class="minibtn" data-demo="Tieengs Vieejt tuyeejt vowif!">Ví dụ: Tiếng Việt</button>
-      <button class="minibtn" data-demo="Chaof buooir sasng ">Ví dụ: Chào buổi sáng</button>
+      <button class="minibtn" id="demoBtn1" data-demo="Tieengs Vieejt tuyeejt vowif!">Ví dụ: Tiếng Việt</button>
+      <button class="minibtn" id="demoBtn2" data-demo="Chaof buooir sasng ">Ví dụ: Chào buổi sáng</button>
       <button class="minibtn" id="sandboxClear">Xoá</button>
     </div>
     <div class="kbd-note">💡 Ô thử này cần bàn phím thật. Bấm <b>dấu cách</b> để kết thúc một từ. Trong <a href="lessons/" style="color:#d4a94a">lớp học</a> có bàn phím trên màn hình — dùng được cả máy tính bảng.</div>
@@ -313,6 +313,12 @@
     });
   });
   document.getElementById('sandboxClear').addEventListener('click', function () { sandbox.reset(); sandbox.el.focus(); });
+  // Let the landing-page i18n retranslate the placeholder (updates both the
+  // current .ph span and future re-renders after reset).
+  window.__sandboxSetPlaceholder = function (t) {
+    sandbox.placeholder = t;
+    var ph = document.querySelector('#sandbox .ph'); if (ph) ph.textContent = t;
+  };
 
   // ── Cheat sheet ────────────────────────────────────────────────────────
   var CHEAT = [
@@ -343,6 +349,7 @@
     }
     var chip = document.createElement('div'); chip.className = 'chip'; chip.setAttribute('role', 'button'); chip.tabIndex = 0;
     chip.title = c.ex;
+    chip.setAttribute('data-res-vi', c.res); chip.setAttribute('data-ex-vi', c.ex);
     chip.innerHTML = '<span class="keys">' + escapeHtml(c.keys) + '</span><span class="arrow">→</span>' +
       '<span class="res">' + escapeHtml(c.res) + '</span>';
     function play() {
@@ -398,13 +405,26 @@
     groups: { 'Dấu thanh (gõ ở cuối từ)': 'Tones (typed at the end of the word)',
               'Nguyên âm đội mũ ^': 'Hatted vowels ^',
               'Nguyên âm có móc/ngoặc': 'Hooked vowels',
-              'Đặc biệt': 'Special' }
+              'Đặc biệt': 'Special' },
+    navClass: '🎓 Enter the classroom', navHome: '← Home',
+    why1: '<h3><span class="e">🎵</span>Tone marks</h3><p><b>s f r x j</b> = the five tones. Type the tone at the end of the word: <code>casa? </code> e.g. <code>caf</code> → cà, <code>hoir</code> → hỏi.</p>',
+    why2: '<h3><span class="e">🔤</span>Hatted vowels</h3><p>Double the letter: <b>aa</b>→â, <b>ee</b>→ê, <b>oo</b>→ô. Add a hook/horn: <b>aw</b>→ă, <b>ow</b>→ơ, <b>uw</b>→ư.</p>',
+    why3: '<h3><span class="e">✨</span>The letter đ &amp; clearing tones</h3><p><b>dd</b>→đ. Type <b>z</b> to clear a tone you just added. Typing the same tone key again also clears it.</p>',
+    why4: '<h3><span class="e">🧠</span>Mistakes are fine</h3><p>The IME recognises non-Vietnamese words (like <code>google</code>) and leaves them alone. Just type naturally; if it’s wrong, delete and retype.</p>',
+    footer: 'Part of <a href="../">ViệtTelex</a> — the open-source Vietnamese input method for macOS.<br>The same rule set that runs in the real app. © 2026 Phil Trịnh · <a href="https://github.com/ptrinh/viettelex">GitHub</a>',
+    cheatText: { '⌫ dấu': '⌫ tone', 'xoá dấu vừa bỏ': 'clear the tone you just added' },
+    demoBtn1: 'Example: Tiếng Việt', demoBtn2: 'Example: Chào buổi sáng',
+    clearBtn: 'Clear', sandboxPh: 'Type here… e.g. xin chaof'
   };
   var SEL = [
     ['.hero h1', 'heroH1'], ['.hero p.sub', 'heroSub'], ['.sandbox .label', 'sandboxLabel'],
     ['.kbd-note', 'kbdNote'], ['#hoc h2', 'hocH2'], ['#hoc .lead', 'hocLead'],
     ['.cta-btn', 'ctaBtn'], ['#hoc .wrap > p:last-child', 'ctaNote'],
-    ['#cheatH2', 'cheatH2'], ['#cheatLead', 'cheatLead']
+    ['#cheatH2', 'cheatH2'], ['#cheatLead', 'cheatLead'],
+    ['#navClass', 'navClass'], ['#navHome', 'navHome'],
+    ['#why1', 'why1'], ['#why2', 'why2'], ['#why3', 'why3'], ['#why4', 'why4'],
+    ['#pageFooter', 'footer'],
+    ['#demoBtn1', 'demoBtn1'], ['#demoBtn2', 'demoBtn2'], ['#sandboxClear', 'clearBtn']
   ];
   var saved = null, cache = {};
   function state() {
@@ -416,6 +436,8 @@
     saved = {};
     SEL.forEach(function (m) { var el = document.querySelector(m[0]); if (el) saved[m[1]] = el.innerHTML; });
     saved.groups = Array.prototype.map.call(document.querySelectorAll('.cheat-group-title'), function (g) { return g.textContent; });
+    var ph0 = document.querySelector('#sandbox .ph');
+    saved.sandboxPh = ph0 ? ph0.textContent : 'Gõ ở đây… ví dụ: xin chaof';
   }
   function apply(lang, dict) {
     snapshot();
@@ -431,13 +453,30 @@
       var groups = (dict && dict.groups) || EN.groups;
       g.textContent = groups[vi] || (EN.groups[vi] || vi);
     });
+    // Cheat tiles: only strings carrying a Vietnamese word need translating
+    // (the char results and telex formulae are language-neutral). Chips keep
+    // their authored VN res/ex in data-* attributes.
+    var ct = (dict && dict.cheatText) || EN.cheatText;
+    document.querySelectorAll('.cheat .chip').forEach(function (chip) {
+      var rv = chip.getAttribute('data-res-vi'), ev = chip.getAttribute('data-ex-vi');
+      var res = (lang === 'vi') ? rv : (ct[rv] || EN.cheatText[rv] || rv);
+      var ex = (lang === 'vi') ? ev : (ct[ev] || EN.cheatText[ev] || ev);
+      var rs = chip.querySelector('.res'); if (rs) rs.textContent = res;
+      chip.title = ex;
+    });
+    var phText = (lang === 'vi') ? saved.sandboxPh : ((dict && dict.sandboxPh) || EN.sandboxPh);
+    if (window.__sandboxSetPlaceholder) window.__sandboxSetPlaceholder(phText);
     document.documentElement.lang = lang;
   }
   function setLang(lang) {
     if (lang === 'vi' || lang === 'en') { apply(lang, null); return; }
     if (cache[lang]) { apply(lang, cache[lang]); return; }
     fetch('lessons/i18n/' + lang + '.json').then(function (r) { return r.json(); })
-      .then(function (j) { cache[lang] = j.landing || {}; apply(lang, cache[lang]); })
+      .then(function (j) {
+        var L = j.landing || {};
+        if (Array.isArray(L.why)) L.why.forEach(function (w, i) { L['why' + (i + 1)] = w; });
+        cache[lang] = L; apply(lang, cache[lang]);
+      })
       .catch(function () { apply('en', null); });
   }
   var sel = document.getElementById('langSel');

--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -152,8 +152,8 @@
   </a>
   <div class="right">
     <select id="langSel" class="langsel" aria-label="Ngôn ngữ / Language">
-      <option value="vi">🌐 Tiếng Việt</option>
-      <option value="en">🌐 English</option>
+      <option value="vi">🇻🇳 Tiếng Việt</option>
+      <option value="en">🇬🇧 English</option>
     </select>
     <a class="back" id="navClass" href="lessons/">🎓 Vào lớp học</a>
     <a class="back" id="navHome" href="../">← Trang chủ</a>
@@ -388,8 +388,8 @@
   // Landing-page i18n. vi = authored DOM, en = built-in map, other languages
   // lazy-load lessons/i18n/<code>.json (.landing section). Shared vtlearn.lang.
   var LANGS = [
-    ['vi', 'Tiếng Việt'], ['en', 'English'], ['fr', 'Français'], ['de', 'Deutsch'],
-    ['ko', '한국어'], ['ja', '日本語'], ['zh', '简体中文'], ['km', 'ខ្មែរ']
+    ['vi', 'Tiếng Việt', '🇻🇳'], ['en', 'English', '🇬🇧'], ['fr', 'Français', '🇫🇷'], ['de', 'Deutsch', '🇩🇪'],
+    ['ko', '한국어', '🇰🇷'], ['ja', '日本語', '🇯🇵'], ['zh', '简体中文', '🇨🇳'], ['km', 'ខ្មែរ', '🇰🇭']
   ];
   var EN = {
     heroH1: 'Learn Vietnamese <span class="accent">Telex</span> typing',
@@ -480,7 +480,7 @@
       .catch(function () { apply('en', null); });
   }
   var sel = document.getElementById('langSel');
-  sel.innerHTML = LANGS.map(function (l) { return '<option value="' + l[0] + '">🌐 ' + l[1] + '</option>'; }).join('');
+  sel.innerHTML = LANGS.map(function (l) { return '<option value="' + l[0] + '">' + l[2] + ' ' + l[1] + '</option>'; }).join('');
   var st0 = state();
   var lang = st0.lang;
   if (!st0.langChosen) {

--- a/docs/learn/learn.js
+++ b/docs/learn/learn.js
@@ -140,14 +140,14 @@ var STR = {
 // Supported languages. vi/en are built-in; the rest lazy-load i18n/<code>.json
 // (translated by design-time agents from i18n/_template.en.json).
 var LANGS = [
-  { code: 'vi', native: 'Tiếng Việt' },
-  { code: 'en', native: 'English' },
-  { code: 'fr', native: 'Français' },
-  { code: 'de', native: 'Deutsch' },
-  { code: 'ko', native: '한국어' },
-  { code: 'ja', native: '日本語' },
-  { code: 'zh', native: '简体中文' },
-  { code: 'km', native: 'ខ្មែរ' }
+  { code: 'vi', native: 'Tiếng Việt', flag: '🇻🇳' },
+  { code: 'en', native: 'English', flag: '🇬🇧' },
+  { code: 'fr', native: 'Français', flag: '🇫🇷' },
+  { code: 'de', native: 'Deutsch', flag: '🇩🇪' },
+  { code: 'ko', native: '한국어', flag: '🇰🇷' },
+  { code: 'ja', native: '日本語', flag: '🇯🇵' },
+  { code: 'zh', native: '简体中文', flag: '🇨🇳' },
+  { code: 'km', native: 'ខ្មែរ', flag: '🇰🇭' }
 ];
 var EXTRA = {};   // lang -> fetched i18n json (chapters/lessons/hands/hoc)
 function isBuiltinLang(c) { return c === 'vi' || c === 'en'; }
@@ -483,7 +483,7 @@ var kb = null;
 function populateLangSel() {
   if (gb.lang.options.length === LANGS.length) return;
   gb.lang.innerHTML = LANGS.map(function (l) {
-    return '<option value="' + l.code + '">🌐 ' + l.native + '</option>';
+    return '<option value="' + l.code + '">' + l.flag + ' ' + l.native + '</option>';
   }).join('');
 }
 function renderBar() {

--- a/docs/learn/lessons/i18n/_template.en.json
+++ b/docs/learn/lessons/i18n/_template.en.json
@@ -296,6 +296,14 @@
    "<h3><span class=\"e\">✨</span>The letter đ &amp; clearing tones</h3><p><b>dd</b>→đ. Type <b>z</b> to clear a tone you just added. Typing the same tone key again also clears it.</p>",
    "<h3><span class=\"e\">🧠</span>Mistakes are fine</h3><p>The IME recognises non-Vietnamese words (like <code>google</code>) and leaves them alone. Just type naturally; if it’s wrong, delete and retype.</p>"
   ],
-  "footer": "Part of <a href=\"../\">ViệtTelex</a> — the open-source Vietnamese input method for macOS.<br>The same rule set that runs in the real app. © 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>"
+  "footer": "Part of <a href=\"../\">ViệtTelex</a> — the open-source Vietnamese input method for macOS.<br>The same rule set that runs in the real app. © 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>",
+  "cheatText": {
+   "⌫ dấu": "⌫ tone",
+   "xoá dấu vừa bỏ": "clear the tone you just added"
+  },
+  "demoBtn1": "Example: Tiếng Việt",
+  "demoBtn2": "Example: Chào buổi sáng",
+  "clearBtn": "Clear",
+  "sandboxPh": "Type here… e.g. xin chaof"
  }
 }

--- a/docs/learn/lessons/i18n/de.json
+++ b/docs/learn/lessons/i18n/de.json
@@ -295,6 +295,14 @@
    "<h3><span class=\"e\">✨</span>Der Buchstabe đ &amp; Töne löschen</h3><p><b>dd</b>→đ. Tippe <b>z</b>, um einen gerade gesetzten Ton zu löschen. Dieselbe Ton-Taste erneut zu tippen löscht ihn ebenfalls.</p>",
    "<h3><span class=\"e\">🧠</span>Fehler sind okay</h3><p>Die Eingabemethode erkennt nicht-vietnamesische Wörter (wie <code>google</code>) und lässt sie unangetastet. Tippe einfach natürlich; wenn es falsch ist, lösche und tippe neu.</p>"
   ],
-  "footer": "<a href=\"../\">ViệtTelex</a> — die quelloffene vietnamesische Eingabemethode für macOS.<br>Dasselbe Regelwerk wie in der echten App. © 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>"
+  "footer": "<a href=\"../\">ViệtTelex</a> — die quelloffene vietnamesische Eingabemethode für macOS.<br>Dasselbe Regelwerk wie in der echten App. © 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>",
+  "cheatText": {
+   "⌫ dấu": "⌫ Ton",
+   "xoá dấu vừa bỏ": "löscht den eben gesetzten Ton"
+  },
+  "demoBtn1": "Beispiel: Tiếng Việt",
+  "demoBtn2": "Beispiel: Chào buổi sáng",
+  "clearBtn": "Löschen",
+  "sandboxPh": "Hier tippen… z. B. xin chaof"
  }
 }

--- a/docs/learn/lessons/i18n/fr.json
+++ b/docs/learn/lessons/i18n/fr.json
@@ -295,6 +295,14 @@
    "<h3><span class=\"e\">✨</span>La lettre đ &amp; l'effacement des tons</h3><p><b>dd</b>→đ. Tape <b>z</b> pour effacer un ton que tu viens d'ajouter. Retaper la même touche de ton l'efface aussi.</p>",
    "<h3><span class=\"e\">🧠</span>Les erreurs, c'est normal</h3><p>L'IME reconnaît les mots non vietnamiens (comme <code>google</code>) et les laisse tels quels. Tape naturellement ; si c'est faux, efface et retape.</p>"
   ],
-  "footer": "<a href=\"../\">ViệtTelex</a> — la méthode de saisie vietnamienne open-source pour macOS.<br>Le même ensemble de règles que dans la vraie application. © 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>"
+  "footer": "<a href=\"../\">ViệtTelex</a> — la méthode de saisie vietnamienne open-source pour macOS.<br>Le même ensemble de règles que dans la vraie application. © 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>",
+  "cheatText": {
+   "⌫ dấu": "⌫ accent",
+   "xoá dấu vừa bỏ": "efface l’accent qu’on vient d’ajouter"
+  },
+  "demoBtn1": "Exemple : Tiếng Việt",
+  "demoBtn2": "Exemple : Chào buổi sáng",
+  "clearBtn": "Effacer",
+  "sandboxPh": "Tapez ici… ex. : xin chaof"
  }
 }

--- a/docs/learn/lessons/i18n/ja.json
+++ b/docs/learn/lessons/i18n/ja.json
@@ -295,6 +295,14 @@
    "<h3><span class=\"e\">✨</span>đ の文字と声調を消す</h3><p><b>dd</b>→đ。いま付けた声調は <b>z</b> をおすと消せます。同じ声調キーをもう一度おしても消えます。</p>",
    "<h3><span class=\"e\">🧠</span>まちがえてもだいじょうぶ</h3><p>IME はベトナム語じゃない言葉（<code>google</code> など）を見わけて、そのままにしてくれます。ふつうにタイプしてね。ちがったら消してタイプしなおそう。</p>"
   ],
-  "footer": "<a href=\"../\">ViệtTelex</a> — macOS 用のオープンソースなベトナム語入力メソッド。<br>本物のアプリとまったく同じルールで動きます。© 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>"
+  "footer": "<a href=\"../\">ViệtTelex</a> — macOS 用のオープンソースなベトナム語入力メソッド。<br>本物のアプリとまったく同じルールで動きます。© 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>",
+  "cheatText": {
+   "⌫ dấu": "⌫ 声調",
+   "xoá dấu vừa bỏ": "直前に付けた声調を消す"
+  },
+  "demoBtn1": "例: Tiếng Việt",
+  "demoBtn2": "例: Chào buổi sáng",
+  "clearBtn": "クリア",
+  "sandboxPh": "ここに入力… 例: xin chaof"
  }
 }

--- a/docs/learn/lessons/i18n/km.json
+++ b/docs/learn/lessons/i18n/km.json
@@ -295,6 +295,14 @@
    "Nguyên âm đội mũ ^": "ស្រៈពាក់មួក ^",
    "Nguyên âm có móc/ngoặc": "ស្រៈមានទំពក់",
    "Đặc biệt": "ពិសេស"
-  }
+  },
+  "cheatText": {
+   "⌫ dấu": "⌫ សំឡេង",
+   "xoá dấu vừa bỏ": "លុបសំឡេងដែលទើបដាក់"
+  },
+  "demoBtn1": "ឧទាហរណ៍៖ Tiếng Việt",
+  "demoBtn2": "ឧទាហរណ៍៖ Chào buổi sáng",
+  "clearBtn": "សម្អាត",
+  "sandboxPh": "វាយនៅទីនេះ… ឧ. xin chaof"
  }
 }

--- a/docs/learn/lessons/i18n/ko.json
+++ b/docs/learn/lessons/i18n/ko.json
@@ -295,6 +295,14 @@
    "<h3><span class=\"e\">✨</span>đ 글자 &amp; 성조 지우기</h3><p><b>dd</b>→đ. 방금 붙인 성조를 지우려면 <b>z</b>를 눌러요. 같은 성조 키를 다시 눌러도 지워져요.</p>",
    "<h3><span class=\"e\">🧠</span>틀려도 괜찮아요</h3><p>IME는 베트남어가 아닌 낱말(예: <code>google</code>)을 알아보고 그대로 둬요. 편하게 입력하고, 틀리면 지우고 다시 쳐요.</p>"
   ],
-  "footer": "<a href=\"../\">ViệtTelex</a> — macOS를 위한 오픈 소스 베트남어 입력 방식이에요.<br>실제 앱에서 돌아가는 규칙 그대로예요. © 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>"
+  "footer": "<a href=\"../\">ViệtTelex</a> — macOS를 위한 오픈 소스 베트남어 입력 방식이에요.<br>실제 앱에서 돌아가는 규칙 그대로예요. © 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>",
+  "cheatText": {
+   "⌫ dấu": "⌫ 성조",
+   "xoá dấu vừa bỏ": "방금 넣은 성조를 지우기"
+  },
+  "demoBtn1": "예시: Tiếng Việt",
+  "demoBtn2": "예시: Chào buổi sáng",
+  "clearBtn": "지우기",
+  "sandboxPh": "여기에 입력… 예: xin chaof"
  }
 }

--- a/docs/learn/lessons/i18n/zh.json
+++ b/docs/learn/lessons/i18n/zh.json
@@ -295,6 +295,14 @@
    "<h3><span class=\"e\">✨</span>字母 đ 与清除音调</h3><p><b>dd</b>→đ。打 <b>z</b> 可以清除你刚加上的音调。再打一次同一个音调键也能清除它。</p>",
    "<h3><span class=\"e\">🧠</span>打错也没关系</h3><p>输入法能识别非越南语的词（比如 <code>google</code>）并保持原样。放心自然地打；如果错了，删掉重打就行。</p>"
   ],
-  "footer": "<a href=\"../\">ViệtTelex</a> — 面向 macOS 的开源越南语输入法。<br>与真正的 App 运行的是同一套规则。© 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>"
+  "footer": "<a href=\"../\">ViệtTelex</a> — 面向 macOS 的开源越南语输入法。<br>与真正的 App 运行的是同一套规则。© 2026 Phil Trịnh · <a href=\"https://github.com/ptrinh/viettelex\">GitHub</a>",
+  "cheatText": {
+   "⌫ dấu": "⌫ 声调",
+   "xoá dấu vừa bỏ": "清除刚加的声调"
+  },
+  "demoBtn1": "示例：Tiếng Việt",
+  "demoBtn2": "示例：Chào buổi sáng",
+  "clearBtn": "清除",
+  "sandboxPh": "在此输入… 例：xin chaof"
  }
 }

--- a/docs/learn/lessons/index.html
+++ b/docs/learn/lessons/index.html
@@ -75,8 +75,8 @@
   </a>
   <div class="right">
     <select id="langSel" class="langsel" aria-label="Ngôn ngữ / Language">
-      <option value="vi">🌐 Tiếng Việt</option>
-      <option value="en">🌐 English</option>
+      <option value="vi">🇻🇳 Tiếng Việt</option>
+      <option value="en">🇬🇧 English</option>
     </select>
     <a class="back" href="../">✏️ Gõ thử & quy tắc</a>
     <a class="back" href="../../">← Trang chủ</a>


### PR DESCRIPTION
Trang /learn/index.html dùng hệ i18n **inline riêng** (không nạp learn.js), nên phần nav / thẻ 'Cần nhớ nhất' / footer thêm vào learn.js trước đó không áp dụng ở landing. PR này bổ sung trực tiếp vào i18n inline của landing:

- Nav (Vào lớp học / Trang chủ), 4 thẻ 'Cần nhớ nhất', footer
- Placeholder ô gõ thử, 2 nút ví dụ, nút Xoá
- Cheat tile `z → ⌫ dấu` + tooltip (dịch chữ 'dấu' / 'xoá dấu vừa bỏ')

Đủ 8 ngôn ngữ. Verified trên trình duyệt (EN + KO): không còn chữ Việt sót (trừ brand tagline + cụm ví dụ tiếng Việt, giữ cố ý).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019v1AVYDEzBiX6T7aiUErK1