### PR TITLE
ci: build trên macos-26 (SDK macOS 26 cho .glassProminent)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: TelexCore tests
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: swift test
@@ -21,7 +21,7 @@ jobs:
 
   build:
     name: Build app (unsigned)
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Install XcodeGen


### PR DESCRIPTION
## Vấn đề
CI `build` job fail: `SettingsWindow.swift:323 error: reference to member 'glassProminent' cannot be resolved`.

`.glassProminent` là symbol của SDK macOS 26. Runner `macos-15` dùng Xcode cũ không có SDK này, nên fail compile dù code đã guard bằng `#available(macOS 26.0, *)` (guard chỉ tránh chạy runtime, symbol vẫn cần có ở compile time).

## Fix
Chuyển cả 2 job sang `runs-on: macos-26` (có Xcode 26 + SDK macOS 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)