### PR TITLE
fix(settings): banner quyền Trợ năng tự cập nhật ngay khi user cấp quyền

### DIFF
--- a/App/Sources/SettingsWindow.swift
+++ b/App/Sources/SettingsWindow.swift
@@ -120,10 +120,12 @@ final class SettingsModel: ObservableObject {
     /// Rows the user added by hand this session but hasn't pinned yet (mode still
     /// auto, nothing learned) — kept visible so the dropdown can be used on them.
     private var addedApps: Set<String> = []
-    /// Snapshot of `Accessibility.isTrusted` for the General-tab warning banner. NOT
-    /// polled: refreshed on appear and when the Settings window regains key, the same
-    /// event-driven refresh the mode table uses (AX trust only changes while the user is
-    /// away in System Settings, so coming back is exactly the moment to re-read it).
+    /// Snapshot of the AX trust state for the General-tab warning banner. NOT polled:
+    /// refreshed on appear, when the Settings window regains key, and — since the user
+    /// does not have to come back to this window at all — the moment macOS says the
+    /// Accessibility list changed (`com.apple.accessibility.api`, the same signal
+    /// `main.swift` uses to rebuild the tap). Coming back used to be the ONLY trigger,
+    /// which left the red warning standing next to a checkbox the user had just ticked.
     @Published var accessibilityTrusted: Bool = Accessibility.isTrusted
 
     init(selected: SettingsTab) {
@@ -154,9 +156,24 @@ final class SettingsModel: ObservableObject {
     func loc(_ key: String) -> String { VTLocalized(key) }
 
     /// Re-read the Accessibility trust snapshot (see `accessibilityTrusted`).
+    /// `readTrustNow`, not `isTrusted`: this is a UI path, and the cached reader can
+    /// serve the pre-grant answer while its background probe is still in flight.
     func refreshAccessibilityStatus() {
-        let now = Accessibility.isTrusted
+        let now = Accessibility.readTrustNow()
         if now != accessibilityTrusted { accessibilityTrusted = now }
+    }
+
+    /// The Accessibility list changed while the user was in System Settings. Re-read
+    /// NOW and once more after 1.5s: right after the toggle tccd can still report the
+    /// OLD value (the same race `TerminalTapController.trustMayHaveChanged` guards
+    /// against with the same delay), so an immediate read alone can latch the banner
+    /// into lying in the other direction — claiming permission is fine right after a
+    /// REVOKE. Two reads, no timer, no polling.
+    func accessibilityMayHaveChanged() {
+        refreshAccessibilityStatus()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            self?.refreshAccessibilityStatus()
+        }
     }
 
     /// Open System Settings → Privacy & Security → Accessibility. One definition, used
@@ -576,6 +593,15 @@ struct GeneralTab: View {
         // comes back, which makes this window key again.
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
             model.refreshAccessibilityStatus()
+        }
+        // …and the moment the checkbox is ticked, WITHOUT waiting for the user to come
+        // back here. System Settings keeps the focus after a grant, so with only the
+        // didBecomeKey trigger above the red warning stayed on screen next to a
+        // permission that was already live — reported as "cấp quyền rồi nhưng vẫn báo".
+        // Same distributed notification main.swift already observes for the tap.
+        .onReceive(DistributedNotificationCenter.default()
+            .publisher(for: Notification.Name("com.apple.accessibility.api"))) { _ in
+            model.accessibilityMayHaveChanged()
         }
     }
 }

--- a/App/Sources/TerminalTap.swift
+++ b/App/Sources/TerminalTap.swift
@@ -149,6 +149,23 @@ enum Accessibility {
         kickRefresh()
     }
 
+    /// Synchronous, cache-bypassing read for UI paths (the Settings banner). NEVER
+    /// call this from the keystroke path — that is what `isTrusted` and its cache are
+    /// for. The distinction matters: a stale-TTL read of `isTrusted` returns
+    /// `.serveCachedAndRefresh`, i.e. it hands back the OLD value and only converges
+    /// on a background round trip. That is correct for a keystroke (a microsecond of
+    /// staleness, and the paths that must not be wrong read TCC directly) and wrong
+    /// for a banner the user is staring at one second after ticking the checkbox in
+    /// System Settings: nothing re-reads afterwards, so the warning kept claiming
+    /// "no permission" until some later event happened to make the window key again.
+    @discardableResult
+    static func readTrustNow() -> Bool {
+        #if DEBUG
+        if let forced = testTrustOverride { return forced }
+        #endif
+        return syncRefresh()
+    }
+
     #if DEBUG
     /// Test seams: drive the cache without a live TCC grant.
     static func _testSetTrustCache(_ value: Bool) {


### PR DESCRIPTION
Banner chỉ re-evaluate ở onAppear + didBecomeKey. Nhưng System Settings GIỮ focus sau khi user tick checkbox, nên cửa sổ Cài đặt không bao giờ thành key lại → chữ đỏ "chưa có quyền" đứng nguyên cạnh một quyền đã sống. Field report: "cấp quyền rồi nhưng vẫn báo" — user phải click lại vào cửa sổ, hoặc logout.

Hai nguyên nhân độc lập, sửa cả hai:

1. Thiếu trigger. Nay subscribe com.apple.accessibility.api qua DistributedNotificationCenter — CÙNG signal main.swift đã observe để dựng lại tap. App vốn đã event-driven cho tap; chỉ banner bị bỏ sót.

2. Đọc ra giá trị cũ. refreshAccessibilityStatus() gọi Accessibility.isTrusted, mà reader đó khi hết TTL trả .serveCachedAndRefresh: hand back giá trị CŨ rồi mới refresh ở background. Đúng cho keystroke path (cache tồn tại chính vì thế, và các path không được sai thì đọc TCC trực tiếp), sai cho UI — lần refresh đầu sau khi cấp quyền vẫn đọc false, và không có gì đọc lại nữa. Nên kể cả khi cửa sổ thành key lại, banner vẫn có thể đỏ. Thêm Accessibility.readTrustNow(): đồng bộ, bỏ qua cache, CHỈ dành cho UI path. Vẫn honor testTrustOverride trong #if DEBUG — không có nó thì SettingsModelTests/GonhanhHardeningTests sẽ đọc trạng thái TCC thật của máy build và fail tuỳ máy.

Đọc 2 lần cách 1.5s: ngay sau toggle tccd còn trả giá trị CŨ (cùng race và cùng con số delay mà TerminalTapController.trustMayHaveChanged đã phòng). Một lần đọc duy nhất có thể latch banner sai theo chiều ngược lại — báo "quyền OK" ngay sau khi user THU HỒI quyền. Không timer, không polling.

Xoá luôn nhu cầu "You may need to restart your Mac" trong chính text cảnh báo.