### PR TITLE
fix(engine): ⌫ xoá dấu cách mở lại từ vừa chốt - issue #40

### DIFF
--- a/App/Sources/TelexInputController.swift
+++ b/App/Sources/TelexInputController.swift
@@ -414,11 +414,19 @@ final class TelexInputController: IMKInputController {
 
         switch event.keyCode {
         case kDelete:
-            // Backspacing with an empty buffer deletes previously-committed text: the
-            // "previous word" relationship is now unclear, so drop the English context
-            // (undetermined → Vietnamese). In-word backspace (buffer non-empty) keeps it —
-            // the preceding word hasn't changed.
-            if engine.isEmpty { engine.resetContext(); return false }
+            if engine.isEmpty {
+                // ⌫ on the boundary character the last word ended with puts the caret
+                // back at that word's end, and the user is going to keep editing it
+                // ("tháy" ␣ ⌫ then `a` → "thấy" — issue #40). Re-open it into the buffer
+                // so the next key modifies the word instead of starting a new one.
+                if tryReopenLastCommit(client, id: id) { return false }
+                // Backspacing with an empty buffer deletes previously-committed text: the
+                // "previous word" relationship is now unclear, so drop the English context
+                // (undetermined → Vietnamese). In-word backspace (buffer non-empty) keeps it —
+                // the preceding word hasn't changed.
+                engine.resetContext()
+                return false
+            }
             // Our tracked window must still MATCH the field before we rewrite it. A
             // ⌫-rewrite is `insertText(composed, range(anchor, onLen))`: if the app has
             // meanwhile moved the caret, re-rendered (React-controlled inputs do), or
@@ -524,6 +532,11 @@ final class TelexInputController: IMKInputController {
             let wasEdge = edgeTapWord
             let rewrote = boundary(client)
             boundaryCommitInFlight = false
+            // Return/Tab/Esc do not put ONE character after the word the way a space
+            // does — Enter sends the message in a chat app, Tab moves focus, Esc
+            // inserts nothing — so a following ⌫ is not deleting a boundary character
+            // and must not re-open the word (see tryReopenLastCommit).
+            engine.forgetLastCommit()
             logDecision("boundary-key code=\(event.keyCode) rewrote=\(rewrote)")
             // When the commit REWROTE the word (gõ tắt "ko"→"không", auto-restore
             // "thooiiii"), web-view editors (WhatsApp) apply that insertText
@@ -581,6 +594,10 @@ final class TelexInputController: IMKInputController {
             let boundaryChar = event.characters?.utf8.first
             let wasEdge = edgeTapWord
             let rewrote = boundary(client, suppressAutoRestore: boundaryChar.map(isBracket) ?? false)
+            // Only a key that leaves exactly ONE character after the word may be
+            // ⌫-ed back into it (issue #40). Arrow/function keys land here too — they
+            // move the caret and insert nothing, so the word is no longer adjacent.
+            if !Self.insertsOneCharacter(event.characters) { engine.forgetLastCommit() }
             // Edge word rewritten at the boundary (shortcut/auto-restore): the
             // rewrite is a synthetic burst still in the session queue — a native
             // boundary key would overtake it. Same cure as Return below: swallow
@@ -773,6 +790,18 @@ final class TelexInputController: IMKInputController {
 
     // MARK: - Re-edit the word before the caret (experimental)
 
+    /// Does this key put exactly ONE printable character on screen after the word it
+    /// just ended? Only then is the next ⌫ deleting a boundary character, which is the
+    /// precondition for re-opening the word (issue #40, see `tryReopenLastCommit`).
+    /// Printable ASCII only: a non-ascii scalar (arrow/function keys arrive as
+    /// U+F700…, option-key symbols as real text) either isn't inserted at all or isn't
+    /// something worth reasoning about. Pure so the rule is pinned by tests.
+    static func insertsOneCharacter(_ characters: String?) -> Bool {
+        guard let characters, characters.count == 1,
+              let ascii = characters.first?.asciiValue else { return false }
+        return ascii >= 0x20 && ascii != 0x7F
+    }
+
     /// Keys that can only ever ADD a diacritic, never a letter: the Telex tone keys
     /// (s f r x j), the tone remover (z) and the horn/breve modifier (w) — or, in VNI,
     /// the digits. The doubler letters (a e o d) are deliberately NOT here: they are
@@ -842,6 +871,66 @@ final class TelexInputController: IMKInputController {
         onLen = wordLen
         anchorVerified = true
         DebugLog.log("re-edit \(id ?? "?"): seeded \(wordLen) chars before caret")
+    }
+
+    // MARK: - Re-open the last committed word on ⌫ (issue #40)
+
+    /// The ⌫ about to be delivered deletes the boundary character that ended the last
+    /// word — so put that word back in the buffer, the way every other Vietnamese IME
+    /// does ("tháy" ␣ ⌫ `a` → "thấy" instead of "tháya").
+    ///
+    /// Unlike `tryReEditWord` this never guesses WHICH word: the engine kept the exact
+    /// keystrokes it committed, and only while nothing else touched it since. What is
+    /// still unknown is whether the SCREEN agrees — the app may have swallowed the
+    /// boundary key, autocorrected the word, or moved the caret — so the characters the
+    /// word should occupy are read back and compared before anything is re-opened. On
+    /// any disagreement the composition is dropped and the ⌫ behaves exactly as before.
+    /// Returns true iff the buffer now holds the word; the ⌫ itself always passes
+    /// through and deletes the boundary character.
+    private func tryReopenLastCommit(_ client: IMKTextInput, id: String?) -> Bool {
+        // Marked-text apps commit through setMarkedText/insertText, so the word on
+        // screen is finalized text no composition can reclaim.
+        guard engine.canReopenLastCommit, !usesMarkedNow(id) else { return false }
+        // Same per-FIELD exclusion as `tryReEditWord`: an omnibox/search bar rewrites
+        // text underneath us via inline autocomplete, so the replace that follows a
+        // re-open would land in a field that is editing itself. (Reachable from here
+        // whenever the tap is not running — no Accessibility — and IMKit handles the
+        // browser in-place.)
+        if AppState.shared.usesAxDetect(id), FocusedFieldDetector.wantsSelection {
+            engine.forgetLastCommit()
+            DebugLog.log("⌫ re-open \(id ?? "?"): skipped (field resolves to selection-replace)")
+            return false
+        }
+        let sel = client.selectedRange()
+        // A live SELECTION means this ⌫ deletes that instead of the boundary character,
+        // and with no caret there is no anchor to re-open at. Either way: forget the
+        // word — the boundary character is gone by the next key, so a later ⌫ must not
+        // resurrect it.
+        guard sel.location != NSNotFound, sel.length == 0 else {
+            engine.forgetLastCommit()
+            return false
+        }
+        guard let word = engine.reopenLastCommit() else { return false }
+        let wordLen = (word as NSString).length
+        let start = sel.location - 1 - wordLen          // this ⌫ removes the boundary char
+        guard start >= 0,
+              let sub = client.attributedSubstring(from: NSRange(location: start, length: wordLen)),
+              sub.string == word                        // NFD field ⇒ mismatch ⇒ skip, as intended
+        else {
+            engine.reset()
+            DebugLog.log("⌫ re-open \(id ?? "?"): skipped (screen disagrees)")
+            return false
+        }
+        // The composition IS that on-screen word now: point the tracking window at it,
+        // exactly like the re-edit path does after a successful seed.
+        anchor = start
+        onLen = wordLen
+        tracking = true
+        anchorVerified = true
+        selToClear = 0
+        edgeTapWord = false
+        DebugLog.log("⌫ re-open \(id ?? "?"): \(wordLen) chars back in the buffer")
+        return true
     }
 
     // MARK: - In-place mode (default: no marked text, caret stays at end)
@@ -1490,6 +1579,10 @@ final class TelexInputController: IMKInputController {
             // mid-word — "t","r" became "trồi". Expansion belongs to EXPLICIT
             // boundaries only (space/punctuation/Return/Tab).
             boundary(client, allowShortcuts: false)
+            // A FORCED commit, not a boundary key: nothing was inserted after the word,
+            // so the next ⌫ is deleting the word's own last letter and must not re-open
+            // it (see tryReopenLastCommit).
+            engine.forgetLastCommit()
         } else {
             engine.reset()
             tracking = false

--- a/App/Sources/TerminalTap.swift
+++ b/App/Sources/TerminalTap.swift
@@ -2181,8 +2181,12 @@ final class TerminalTapController {
             // Went inactive with a word half-composed (e.g. the async reconcile above
             // just corrected a stale flag): abandon it so a later re-activate can't
             // resume a stale composition. `engine` is tap-thread confined — reset here,
-            // never from the main-thread paths that flip the flag.
-            if !engine.isEmpty { engine.reset() }
+            // never from the main-thread paths that flip the flag. An EMPTY engine can
+            // still hold the re-open snapshot of the word it just committed, which must
+            // not survive an inactive stretch either — hence the second test, kept as a
+            // cheap Int compare so an idle machine (VietTelex installed, ABC active)
+            // still pays nothing per key.
+            if !engine.isEmpty || engine.canReopenLastCommit { engine.reset() }
             return pass
         }
 
@@ -2194,7 +2198,10 @@ final class TerminalTapController {
         // Runs for ALL apps, before the tap-mode gate.
         let flags = event.flags
         if flags.contains(.maskCommand) || flags.contains(.maskControl) || flags.contains(.maskAlternate) {
-            if !engine.isEmpty { engine.reset() }   // skip the no-op reset when nothing composes
+            // An empty engine can still hold the re-open snapshot, and ⌘A + ⌫ deletes a
+            // SELECTION, not the boundary character that snapshot assumes — so the
+            // no-op skip now tests for it too, still without leaving the fast path.
+            if !engine.isEmpty || engine.canReopenLastCommit { engine.reset() }
             // ALWAYS notify: the IMKit controller's engine state is invisible from here,
             // so we cannot gate this on our own emptiness.
             NotificationCenter.default.post(name: .telexResetComposition, object: nil)
@@ -2305,10 +2312,15 @@ final class TerminalTapController {
         if keyCode == kDelete {
             lastTapKeyWasBoundary = false   // ⌫ is word-adjacent editing, not a boundary
             if engine.isEmpty {
-                // Deleting previously-committed text: the "previous word" is now unclear,
-                // so drop the English context (undetermined → Vietnamese). In-word
-                // backspace (buffer non-empty, below) keeps it — prev word unchanged.
-                engine.resetContext()
+                // ⌫ on the boundary character the last word ended with re-opens that
+                // word ("tháy" ␣ ⌫ then `a` → "thấy" — issue #40); the ⌫ still goes
+                // through and deletes the boundary character either way.
+                if !tryReopenLastCommitTap(id: id) {
+                    // Deleting previously-committed text: the "previous word" is now unclear,
+                    // so drop the English context (undetermined → Vietnamese). In-word
+                    // backspace (buffer non-empty, below) keeps it — prev word unchanged.
+                    engine.resetContext()
+                }
                 // Not composing -> real Backspace, unless a synthetic burst is still
                 // draining (it must land first or the delete hits the wrong char).
                 if SyntheticKeyboard.queueDrained() { return pass }
@@ -2335,6 +2347,11 @@ final class TerminalTapController {
             // enough. Only when auto-restore ACTUALLY rewrote the word (emitBoundary →
             // true) do we suppress + re-emit synthetically, so the boundary key lands
             // AFTER the async edit; otherwise the real key passes through untouched.
+            // None of these leaves ONE character after the word the way a space does
+            // (Enter sends the message, Tab moves focus/completes, Esc inserts
+            // nothing), so a following ⌫ is not deleting a boundary character and must
+            // not re-open the word — see tryReopenLastCommitTap.
+            defer { engine.forgetLastCommit() }
             if engine.isEmpty, SyntheticKeyboard.queueDrained() { return pass }
             if emitBoundary(suppressAutoRestore: false) || !SyntheticKeyboard.queueDrained() {
                 reemit(keyCode: keyCode, string: nil, original: event)
@@ -2352,6 +2369,7 @@ final class TerminalTapController {
             // (no shortcut expansion — not an explicit text boundary)
             lastTapKeyWasBoundary = true
             emitBoundary(suppressAutoRestore: false, allowShortcuts: false)
+            engine.forgetLastCommit()      // nothing predictable landed after the word
             return pass
         }
         // Navigation / function keys (←↑→↓, Home/End/PageUp/PageDown, forward-delete,
@@ -2364,6 +2382,7 @@ final class TerminalTapController {
         if buf[0] < 0x20 || (buf[0] >= 0xF700 && buf[0] <= 0xF8FF) {
             lastTapKeyWasBoundary = true
             emitBoundary(suppressAutoRestore: false, allowShortcuts: false)
+            engine.forgetLastCommit()      // navigation: the caret left the word behind
             return pass
         }
         let ch = Character(scalar)
@@ -2383,6 +2402,11 @@ final class TerminalTapController {
             // nothing here: with no rewrite pending the untouched event is already
             // exactly what should land, in every emit mode.)
             let rewrote = emitBoundary(suppressAutoRestore: isBracketUnichar(buf[0]))
+            // A plain ascii boundary (space, punctuation, digit) leaves exactly ONE
+            // character after the word, which is what makes the next ⌫ re-openable
+            // (issue #40). Anything else — an option-key symbol, a multi-scalar
+            // sequence — is not worth reasoning about: forget the word.
+            if !ch.isASCII { engine.forgetLastCommit() }
             if !rewrote, AppState.shared.tapNativeFastPath, SyntheticKeyboard.queueDrained() {
                 return pass
             }
@@ -2503,6 +2527,39 @@ final class TerminalTapController {
         guard let word = TelexInputController.trailingWord(text) else { return }
         guard (word as NSString).length <= caret, engine.seed(word) else { return }
         DebugLog.log("re-edit(tap) \(id ?? "?"): seeded \((word as NSString).length) chars before caret")
+    }
+
+    // MARK: - Re-open the last committed word on ⌫ (issue #40)
+
+    /// TAP counterpart of `TelexInputController.tryReopenLastCommit`: the ⌫ being
+    /// handled deletes the boundary character that ended the last word, so put that
+    /// word back in the buffer and keep editing it. No anchor bookkeeping is needed
+    /// here — every tap edit targets the live caret — but the same screen check is:
+    /// the characters the word should occupy are read through Accessibility and
+    /// compared before anything is re-opened, so an app that swallowed the boundary
+    /// key or autocorrected the word just gets the old behavior. No AX text (plain
+    /// terminals) means no verification, hence no re-open.
+    /// `.selection`/`.emptyReset` fields are excluded for the same reason re-edit
+    /// excludes them: inline autocomplete rewrites text underneath us.
+    private func tryReopenLastCommitTap(id: String?) -> Bool {
+        guard engine.canReopenLastCommit else { return false }
+        guard emitMode == .backspace, let caret = AXTextEdit.readCaret() else {
+            engine.forgetLastCommit()
+            return false
+        }
+        guard let word = engine.reopenLastCommit() else { return false }
+        let wordLen = (word as NSString).length
+        let start = caret - 1 - wordLen                 // this ⌫ removes the boundary char
+        guard start >= 0,
+              let text = AXTextEdit.readString(at: start, length: wordLen),
+              text == word
+        else {
+            engine.reset()
+            DebugLog.log("⌫ re-open(tap) \(id ?? "?"): skipped (screen disagrees)")
+            return false
+        }
+        DebugLog.log("⌫ re-open(tap) \(id ?? "?"): \(wordLen) chars back in the buffer")
+        return true
     }
 
     /// Emit a shortcut expansion / auto-restore rewrite for the composed word. Returns

--- a/AppTests/AppSupportTests.swift
+++ b/AppTests/AppSupportTests.swift
@@ -504,6 +504,40 @@ final class ReEditWordTapGateTests: XCTestCase {
     }
 }
 
+// Issue #40 — "tháy" ␣ ⌫ then `a` must give "thấy". The engine keeps the committed
+// word (TelexEngine.reopenLastCommit, covered by ReopenTests) but may only put it back
+// when the ⌫ is deleting a BOUNDARY CHARACTER: that is true only if the key that ended
+// the word left exactly one character behind it. This is the pure half of that rule;
+// the read-back that verifies the screen needs a live client/AX tree.
+final class ReopenBoundaryKeyTests: XCTestCase {
+
+    func testPrintableAsciiKeysInsertOneCharacter() {
+        for s in [" ", ".", ",", "!", "-", "5", "(", "/", "~"] {
+            XCTAssertTrue(TelexInputController.insertsOneCharacter(s),
+                          "'\(s)' puts one character after the word")
+        }
+    }
+
+    func testKeysThatInsertNothingOrSomethingElse() {
+        // Arrow / function keys arrive as U+F700… — they move the caret, insert nothing.
+        for scalar: UInt32 in [0xF700, 0xF701, 0xF702, 0xF703, 0xF729, 0xF72B] {
+            XCTAssertFalse(TelexInputController.insertsOneCharacter(String(UnicodeScalar(scalar)!)),
+                           "U+\(String(scalar, radix: 16)) is navigation, not text")
+        }
+        // Control characters (Return/Tab/Esc reach the keycode branch, but iTerm also
+        // delivers arrows as 0x1C–0x1F) and DEL.
+        for scalar: UInt32 in [0x00, 0x09, 0x0D, 0x1B, 0x1C, 0x1F, 0x7F] {
+            XCTAssertFalse(TelexInputController.insertsOneCharacter(String(UnicodeScalar(scalar)!)))
+        }
+        // Non-ascii text and multi-character strings: not worth reasoning about.
+        XCTAssertFalse(TelexInputController.insertsOneCharacter("–"))
+        XCTAssertFalse(TelexInputController.insertsOneCharacter("ơ"))
+        XCTAssertFalse(TelexInputController.insertsOneCharacter("ab"))
+        XCTAssertFalse(TelexInputController.insertsOneCharacter(""))
+        XCTAssertFalse(TelexInputController.insertsOneCharacter(nil))
+    }
+}
+
 // The ⌫ guard: our tracked composition window may only be rewritten while the app's
 // caret still agrees with it. Tester report 2026-07-27 (Chrome Web Store search box):
 // the first ⌫ ate TWO characters and afterwards nothing typed showed up until a space —

--- a/TelexCore/Sources/TelexCore/TelexEngine.swift
+++ b/TelexCore/Sources/TelexCore/TelexEngine.swift
@@ -199,8 +199,28 @@ public struct TelexEngine {
     // a doubler is normal typing.
     private var upperToneKey = false
 
+    // MARK: Re-open snapshot (⌫ right after a word boundary — issue #40)
+    //
+    // The keystrokes of the word the LAST boundary committed, kept only while that
+    // word is still exactly what the screen shows: the commit did not auto-restore
+    // to raw and did not overflow, so `composed` is on screen character for
+    // character. Deleting the boundary character then re-opens the word instead of
+    // starting from nothing ("tháy" ␣ ⌫ a → "thấy"), which is what every other
+    // Vietnamese IME does. Fixed buffers — the capture runs on the boundary hot
+    // path and must not allocate.
+    private var reopenRaw: [UInt8]
+    private var reopenOut: [UInt32]
+    private var reopenRawCount = 0
+    private var reopenOutCount = 0
+    // `previousWordEnglish` as it was BEFORE the commit folded this word in. Re-opening
+    // puts the word back into the buffer, so the context it composes against must be
+    // the one from the word BEFORE it, not the one it just produced.
+    private var reopenPrevEnglish = false
+
     public init() {
         raw = [UInt8](repeating: 0, count: Self.capacity)
+        reopenRaw = [UInt8](repeating: 0, count: Self.capacity)
+        reopenOut = [UInt32](repeating: 0, count: Self.capacity)
         out = [UInt32](repeating: 0, count: Self.capacity)
         scratch = [UInt32](repeating: 0, count: Self.capacity)
         letters = [LetterUnit](repeating: LetterUnit(), count: Self.capacity)
@@ -309,6 +329,11 @@ public struct TelexEngine {
             return .passthrough
         }
         guard rawCount < Self.capacity else { overflowed = true; return .passthrough }
+
+        // First key of a NEW word: whatever the last boundary committed is now two
+        // edits away from the caret, so a later ⌫ must not re-open it (typing then
+        // backspacing all the way back would otherwise resurrect the wrong word).
+        if rawCount == 0 { reopenRawCount = 0; reopenOutCount = 0 }
 
         raw[rawCount] = ascii
         rawCount += 1
@@ -471,12 +496,13 @@ public struct TelexEngine {
     /// composed word is not a valid Vietnamese syllable. Resets the engine.
     /// The caller inserts the boundary character itself afterwards.
     public mutating func commitBoundary(autoRestore: Bool) -> TelexAction {
-        defer { reset() }
-        guard rawCount > 0 else { return .none }
+        defer { resetWord() }
+        guard rawCount > 0 else { reopenRawCount = 0; reopenOutCount = 0; return .none }
         // Overflowed: the 32-char view is stale vs. the screen, so `outCount`
         // backspaces would hit the wrong characters. No restore, no rewrite.
         if overflowed {
             if contextualEnglish { previousWordEnglish = false }   // undetermined → Vietnamese
+            reopenRawCount = 0; reopenOutCount = 0                 // stale prefix: never re-open
             return .none
         }
         // Skip restore when the user cancelled a diacritic on purpose ("iss"→is).
@@ -500,8 +526,60 @@ public struct TelexEngine {
             for i in lcp..<rawCount { s.append(Unicode.Scalar(raw[i])) }
             action = .replace(backspaces: backspaces, insert: String(s))
         }
+        captureReopen(restored: wantsRestore)
         updateContext(restored: wantsRestore)
         return action
+    }
+
+    /// Remember the just-committed word so a ⌫ on the boundary character can put it
+    /// back (see `reopenLastCommit`). Only when the screen ends up showing `composed`:
+    /// a restore-to-raw ("google") or a caller-side rewrite leaves other text there,
+    /// and re-opening would desync the buffer from the screen. Allocation-free.
+    private mutating func captureReopen(restored: Bool) {
+        guard !restored, rawCount > 0 else { reopenRawCount = 0; reopenOutCount = 0; return }
+        for i in 0..<rawCount { reopenRaw[i] = raw[i] }
+        for i in 0..<outCount { reopenOut[i] = out[i] }
+        reopenRawCount = rawCount
+        reopenOutCount = outCount
+        reopenPrevEnglish = previousWordEnglish
+    }
+
+    /// Discard the re-open snapshot: the boundary character the caller inserted after
+    /// a commit is no longer the thing a ⌫ would delete (shortcut expansion, a
+    /// caller-side rewrite, a dropped composition). Cheaper and clearer at the call
+    /// site than a full `reset()`, which also throws away the live word.
+    public mutating func forgetLastCommit() {
+        reopenRawCount = 0
+        reopenOutCount = 0
+    }
+
+    /// True while `reopenLastCommit()` has something to put back.
+    public var canReopenLastCommit: Bool { rawCount == 0 && reopenRawCount > 0 }
+
+    /// RE-OPEN the word the last boundary committed — the ⌫ counterpart of `seed`.
+    /// The user typed a word, ended it, then deleted the boundary character; the word
+    /// is still on screen and they expect to keep editing it ("tháy" ␣ ⌫ then `a` →
+    /// "thấy", issue #40). Replays the remembered keystrokes so tone placement, ươ
+    /// propagation, ⌫ mapping and the boundary decision all behave exactly as if the
+    /// word had never been committed.
+    ///
+    /// Returns the composed word now in the buffer — which is byte-for-byte what the
+    /// screen shows, so the caller can point its tracking window at it — or nil when
+    /// there is nothing to re-open. Like `seed`, the replay is VERIFIED: if a setting
+    /// changed since the commit and the word no longer composes the same, the engine
+    /// resets and nil is returned rather than compose against text it cannot match.
+    /// The snapshot is consumed either way — one ⌫ gets one chance.
+    public mutating func reopenLastCommit() -> String? {
+        guard canReopenLastCommit else { return nil }
+        let n = reopenRawCount
+        let expected = reopenOutCount
+        let prevEnglish = reopenPrevEnglish
+        reset()                                   // consume the snapshot before replaying
+        previousWordEnglish = prevEnglish         // compose against the word BEFORE this one
+        for i in 0..<n { _ = feed(Character(Unicode.Scalar(reopenRaw[i]))) }
+        guard rawCount == n, outCount == expected else { reset(); return nil }
+        for i in 0..<outCount where out[i] != reopenOut[i] { reset(); return nil }
+        return composed
     }
 
     /// Boundary restore decision, shared by both commit paths.
@@ -669,16 +747,18 @@ public struct TelexEngine {
     /// (non-Vietnamese syllables fall back to the raw keystrokes). Resets the engine.
     /// Used by the marked-text controller path.
     public mutating func commitText(autoRestore: Bool) -> String {
-        defer { reset() }
+        defer { resetWord() }
         // Overflowed: never restore to `rawKeystrokes` (only the first 32 keys) —
         // return the composed prefix unchanged; the caller keeps the rest on screen.
         if overflowed {
             if contextualEnglish { previousWordEnglish = false }
+            reopenRawCount = 0; reopenOutCount = 0                 // stale prefix: never re-open
             return composed
         }
         // Decide with the PREVIOUS word's context, then refresh it for the NEXT word
         // (reusing the restore decision — no repeated checks).
         let wantsRestore = autoRestore && outCount > 0 && shouldRestoreRaw()
+        captureReopen(restored: wantsRestore)
         updateContext(restored: wantsRestore)
         return wantsRestore ? rawKeystrokes : composed
     }
@@ -988,7 +1068,19 @@ public struct TelexEngine {
         return false
     }
 
+    /// Drop the current word AND the re-open snapshot. What callers use when the
+    /// composition is abandoned (focus change, app switch, caret moved): after this
+    /// no ⌫ may re-open anything, because the text before the caret is unknown.
     public mutating func reset() {
+        resetWord()
+        reopenRawCount = 0
+        reopenOutCount = 0
+    }
+
+    /// Word state only; the re-open snapshot survives. The boundary commits capture
+    /// the snapshot and then clear the word through THIS — a full `reset()` would
+    /// wipe what they just captured.
+    private mutating func resetWord() {
         rawCount = 0
         outCount = 0
         markCancelled = false

--- a/TelexCore/Tests/TelexCoreTests/ReopenTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/ReopenTests.swift
@@ -1,0 +1,215 @@
+import XCTest
+@testable import TelexCore
+
+// Issue #40 — "thasy" ␣ ⌫ then `a` must give "thấy", not "tháya". A word ended with a
+// space is still the word the user is looking at, so deleting that space has to put it
+// back in the buffer instead of starting from nothing.
+//
+// The snapshot is deliberately narrow: it survives exactly ONE boundary commit that
+// left `composed` on screen, and any other engine input consumes or invalidates it.
+// These tests pin both halves — that it re-opens when it should, and that it does NOT
+// when the screen no longer shows what the buffer would claim.
+final class ReopenTests: XCTestCase {
+
+    private func engine() -> TelexEngine {
+        var e = TelexEngine()
+        e.freeMarking = true; e.simpleTelex = true; e.liveSpellCheck = true
+        return e
+    }
+    private func feed(_ e: inout TelexEngine, _ keys: String) {
+        for ch in keys { _ = e.feed(ch) }
+    }
+
+    // MARK: - The reported repro
+
+    func testIssue40SpaceThenBackspaceThenToneFix() {
+        var e = engine()
+        feed(&e, "thasy")
+        XCTAssertEqual(e.composed, "tháy")               // mistyped tone
+        XCTAssertEqual(e.commitBoundary(autoRestore: true), .none)   // space commits it
+
+        XCTAssertTrue(e.canReopenLastCommit)
+        XCTAssertEqual(e.reopenLastCommit(), "tháy")     // ⌫ deletes the space
+        XCTAssertEqual(e.rawKeystrokes, "thasy")
+
+        // The compensating `a` now lands on the word, not after it.
+        XCTAssertEqual(e.feed("a"), .replace(backspaces: 2, insert: "ấy"))
+        XCTAssertEqual(e.composed, "thấy")
+    }
+
+    /// Re-opening is a full state restore, not a text seed: ⌫ keeps deleting whole
+    /// displayed glyphs through the re-opened word exactly as it would have mid-word.
+    func testBackspaceKeepsWorkingThroughAReopenedWord() {
+        var e = engine()
+        feed(&e, "dduwowngf")
+        XCTAssertEqual(e.composed, "đường")
+        _ = e.commitBoundary(autoRestore: true)
+        XCTAssertEqual(e.reopenLastCommit(), "đường")
+        for expected in ["đườn", "đườ", "đư", "đ", ""] {
+            _ = e.backspace()
+            XCTAssertEqual(e.composed, expected)
+        }
+    }
+
+    /// The whole point of replaying the keystrokes rather than seeding from text: the
+    /// re-opened word behaves as if it had never been committed, so the raw buffer is
+    /// still a faithful generator of the composition (the BackspaceTests invariant).
+    func testReopenRestoresRawGeneratorInvariant() {
+        for keys in ["thasy", "nguwowif", "dduowcj", "vieejt", "hoas", "quoocs", "toans"] {
+            var e = engine()
+            feed(&e, keys)
+            let composed = e.composed
+            _ = e.commitBoundary(autoRestore: true)
+            XCTAssertEqual(e.reopenLastCommit(), composed, "re-open changed \(keys)")
+            XCTAssertEqual(e.rawKeystrokes, keys)
+            var fresh = engine()
+            feed(&fresh, e.rawKeystrokes)
+            XCTAssertEqual(fresh.composed, e.composed, "\(keys) no longer generates itself")
+        }
+    }
+
+    // MARK: - When the screen does NOT show `composed`, nothing may be re-opened
+
+    /// Auto-restore rewrote the word to its raw keystrokes ("gôgle" → "google"): the
+    /// buffer's composition is not what is on screen, so re-opening would desync.
+    func testRestoredWordIsNotReopenable() {
+        for keys in ["google", "user"] {
+            var e = engine()
+            feed(&e, keys)
+            guard case .replace = e.commitBoundary(autoRestore: true) else {
+                return XCTFail("expected \(keys) to restore at the boundary")
+            }
+            XCTAssertFalse(e.canReopenLastCommit, "\(keys) restored to raw — not re-openable")
+            XCTAssertNil(e.reopenLastCommit())
+        }
+        // A word the boundary DECIDED to restore is never re-opened even when the
+        // restore was a no-op on screen (live spell-check already froze it literally,
+        // so composed == raw and the commit emitted nothing). English stays English:
+        // re-opening would arm Vietnamese transforms on a word the engine just judged
+        // not to be Vietnamese.
+        for keys in ["paper", "windows", "after", "github"] {
+            var e = engine()
+            feed(&e, keys)
+            XCTAssertEqual(e.composed, keys)
+            XCTAssertEqual(e.commitBoundary(autoRestore: true), .none)
+            XCTAssertFalse(e.canReopenLastCommit, "\(keys) is English — not re-openable")
+        }
+    }
+
+    /// Overflow: the engine's 32-key view is a stale prefix of a longer on-screen word.
+    func testOverflowedWordIsNotReopenable() {
+        var e = engine()
+        feed(&e, String(repeating: "a", count: 40))
+        XCTAssertTrue(e.isOverflowed)
+        _ = e.commitBoundary(autoRestore: true)
+        XCTAssertFalse(e.canReopenLastCommit)
+    }
+
+    func testEmptyBoundaryLeavesNothingToReopen() {
+        var e = engine()
+        XCTAssertEqual(e.commitBoundary(autoRestore: true), .none)
+        XCTAssertFalse(e.canReopenLastCommit)
+        // …and it also clears a snapshot from an earlier word — which is what makes a
+        // SECOND space safe: the ⌫ after it deletes that space, not the word's.
+        feed(&e, "hoas")
+        _ = e.commitBoundary(autoRestore: true)
+        XCTAssertTrue(e.canReopenLastCommit)
+        _ = e.commitBoundary(autoRestore: true)          // second boundary, empty buffer
+        XCTAssertFalse(e.canReopenLastCommit)
+    }
+
+    // MARK: - The snapshot never outlives the boundary character
+
+    /// Typing a new word moves the caret away from the committed one: a ⌫ that later
+    /// empties the buffer must NOT resurrect it (it would be two edits behind).
+    func testTypingANewWordDropsTheSnapshot() {
+        var e = engine()
+        feed(&e, "hoas")
+        _ = e.commitBoundary(autoRestore: true)
+        XCTAssertTrue(e.canReopenLastCommit)
+        _ = e.feed("x")
+        XCTAssertFalse(e.canReopenLastCommit)
+        _ = e.backspace()                                 // buffer empty again…
+        XCTAssertFalse(e.canReopenLastCommit)             // …but the word is long gone
+        XCTAssertNil(e.reopenLastCommit())
+    }
+
+    /// One ⌫ gets one chance: the snapshot is consumed even on a successful re-open,
+    /// so a second ⌫ can never re-open the same word twice.
+    func testSnapshotIsConsumedByTheFirstReopen() {
+        var e = engine()
+        feed(&e, "hoas")
+        _ = e.commitBoundary(autoRestore: true)
+        XCTAssertEqual(e.reopenLastCommit(), "hóa")
+        XCTAssertFalse(e.canReopenLastCommit)
+        e.reset()
+        XCTAssertNil(e.reopenLastCommit())
+    }
+
+    /// `reset()` is what every caller uses when the composition is abandoned (focus
+    /// change, mouse click, app switch) — it must take the snapshot with it, and
+    /// `forgetLastCommit()` must do the same without touching a live word.
+    func testResetAndForgetDropTheSnapshot() {
+        var e = engine()
+        feed(&e, "hoas")
+        _ = e.commitBoundary(autoRestore: true)
+        e.reset()
+        XCTAssertFalse(e.canReopenLastCommit)
+
+        feed(&e, "hoas")
+        _ = e.commitBoundary(autoRestore: true)
+        e.forgetLastCommit()
+        XCTAssertFalse(e.canReopenLastCommit)
+
+        // forgetLastCommit() leaves a live composition alone.
+        feed(&e, "toans")
+        e.forgetLastCommit()
+        XCTAssertEqual(e.composed, "toán")
+    }
+
+    /// A word is only re-openable while the ENGINE still composes it the same way. Flip
+    /// a parse setting between commit and ⌫ and the verified replay must refuse rather
+    /// than compose against text it can no longer reproduce.
+    func testSettingChangeBetweenCommitAndReopenRefuses() {
+        var e = TelexEngine()
+        e.freeMarking = true
+        feed(&e, "thaya")
+        XCTAssertEqual(e.composed, "thây")               // free-marking reached back
+        _ = e.commitBoundary(autoRestore: true)
+        e.freeMarking = false                            // setting flipped under us
+        XCTAssertNil(e.reopenLastCommit())
+        XCTAssertTrue(e.isEmpty)                         // and it left no half state
+    }
+
+    // MARK: - commitText (marked-text path) keeps the same contract
+
+    func testCommitTextCapturesTheSameSnapshot() {
+        var e = engine()
+        feed(&e, "thasy")
+        XCTAssertEqual(e.commitText(autoRestore: true), "tháy")
+        XCTAssertEqual(e.reopenLastCommit(), "tháy")
+
+        var f = engine()
+        feed(&f, "google")
+        XCTAssertEqual(f.commitText(autoRestore: true), "google")   // restored to raw
+        XCTAssertFalse(f.canReopenLastCommit)
+    }
+
+    // MARK: - Cross-word English context
+
+    /// The re-opened word must compose against the context of the word BEFORE it, not
+    /// the one the commit just derived from itself.
+    func testReopenRestoresPreviousWordContext() {
+        var e = engine()
+        e.contextualEnglish = true
+        feed(&e, "the")
+        _ = e.commitBoundary(autoRestore: true)
+        XCTAssertTrue(e.previousWordEnglish)              // "the" opened an English run
+        feed(&e, "hoas")
+        _ = e.commitBoundary(autoRestore: true)
+        XCTAssertFalse(e.previousWordEnglish)             // "hóa" closed it
+        XCTAssertEqual(e.reopenLastCommit(), "hóa")
+        XCTAssertTrue(e.previousWordEnglish,
+                      "re-opened word must see the context of the word before it")
+    }
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -99,6 +99,12 @@ Yêu cầu engine:
 - Double-key hủy dấu (aaa→aa, ss→s) + latch: từ đã hủy dấu là tiếng Anh, các phím sau
   literal.
 - Backspace xóa nguyên ký tự hiển thị cuối (không chỉ pop một phím raw), re-render.
+- Backspace ngay sau ranh giới **mở lại từ vừa chốt** (issue #40): boundary nhớ đúng
+  chuỗi phím nó vừa commit (chỉ khi màn hình đang hiển thị `composed` — không
+  auto-restore, không overflow, không gõ tắt), ⌫ xóa ký tự ranh giới thì replay lại
+  chuỗi đó nên `tháy` ␣ ⌫ `a` → `thấy` thay vì `tháya`. Snapshot chết ngay khi có
+  bất kỳ input nào khác, và chỉ được dùng sau khi **đọc lại text trên màn hình**
+  (IMKit: `attributedSubstring`; tap: AX) đúng bằng từ đó.
 
 Quy tắc ổn định đã rút ra khi implement (chi tiết trong `MACOS_IME_NOTES.md`):
 - Mọi edit đi qua **một kênh có thứ tự duy nhất** (không trộn passthrough hệ thống với


### PR DESCRIPTION
Gõ `thasy` → `tháy`, space, ⌫ xoá dấu cách, rồi gõ `a` để bù dấu: ra `tháya` thay vì `thấy`. Space chốt từ và reset engine sạch; ⌫ với buffer rỗng chỉ resetContext rồi thả phím qua, không có đường nào dựng lại buffer nên `a` là ký tự mới. reEditWord không cứu được: nó chỉ bắt phím dấu THUẦN (s/f/r/x/j/z/w), `a` là chữ cái, và mặc định còn OFF. Mọi bộ gõ khác (iOS/macOS, UniKey, EVKey, OpenKey) đều khôi phục buffer khi ⌫ lùi vào từ đã chốt.

ENGINE — snapshot re-open, buffer cố định, zero-alloc:

commitBoundary/commitText nhớ đúng chuỗi phím vừa chốt, CHỈ khi màn hình đang hiển thị `composed`: không auto-restore về raw (`google` → screen là "google", buffer sẽ là "gôgle" ⇒ desync), không overflow (view 32 ký tự là prefix cũ của màn hình). reopenLastCommit() replay lại chuỗi đó qua feed() nên đặt thanh, lan ươ, ánh xạ ⌫ và quyết định boundary hành xử y như từ chưa từng bị chốt — không có code path thứ hai phải giữ đồng bộ (khác seed(), vốn dựng lại từ TEXT).

Replay được VERIFY như round-trip của seed(): settings đổi giữa commit và ⌫ mà từ không compose ra đúng như cũ thì reset + trả nil, không bao giờ compose đè lên text không tái tạo được. previousWordEnglish cũng khôi phục về giá trị TRƯỚC commit — từ mở lại phải nhìn ngữ cảnh của từ đứng trước nó, không phải ngữ cảnh chính nó vừa sinh ra.

Snapshot hẹp có chủ đích: sống qua đúng MỘT lần commit, chết ngay khi phím đầu của từ mới vào feed(), khi reset() (mất focus, click chuột, đổi app), hoặc khi caller gọi forgetLastCommit(). reset() tách làm hai — resetWord() cho hai đường commit (chúng vừa chụp snapshot xong), reset() công khai xoá cả hai.

CONTROLLERS — cùng một luật ở cả IMKit lẫn tap (máy người báo lỗi đi tap):

1. Chỉ mở lại khi phím kết thúc từ để lại ĐÚNG 1 ký tự ASCII in được (space/dấu câu/số). Return/Tab/Esc/mũi tên/phím chức năng/dead key → forgetLastCommit(): Enter gửi tin nhắn trong app chat, Tab đổi focus, Esc không chèn gì ⇒ ⌫ sau đó không xoá ký tự ranh giới. commitComposition (app force-commit giữa từ) cũng vậy.

2. Trước khi dùng, ĐỌC LẠI text trên màn hình đúng vị trí từ đó và so khớp — IMKit qua attributedSubstring, tap qua AX. Lệch (app nuốt phím ranh giới, autocorrect/text-substitution đổi từ, caret nhảy, field NFD, AX trễ) → bỏ qua, ⌫ hành xử y như trước. Đây là khác biệt cốt lõi với reEditWord vốn ĐOÁN từ trên màn hình rồi seed (regression 1.4.28 → default OFF): ở đây engine biết chính xác từ nào, đọc màn hình chỉ để xác nhận.

3. Loại trừ per-FIELD giống re-edit: omnibox/search bar (inline autocomplete tự viết đè) và app marked-text. Tap thêm điều kiện emitMode == .backspace.

Kèm theo: ⌘/⌃/⌥ và nhánh imeActive trong tap trước bị gate `!engine.isEmpty` nên snapshot sống sót qua ⌘A + ⌫ (⌫ đó xoá SELECTION, không phải ký tự ranh giới) — nay test thêm canReopenLastCommit, vẫn là một phép so Int nên máy đang dùng ABC không trả phí gì mỗi phím.

TelexCore 233 test pass (debug + release), AppTests 167 pass. Zero-allocation invariant giữ nguyên, 0.1545 µs/phím (ceiling 0.40).