### PR TITLE
feat(settings): nút Chép nhật ký gỡ lỗi

### DIFF
--- a/App/Resources/vi.lproj/Localizable.strings
+++ b/App/Resources/vi.lproj/Localizable.strings
@@ -95,9 +95,11 @@
 "Keep this ON. Stops the terminal tap if it ever floods the keyboard with synthetic events, so a bug can’t freeze typing." = "Nên để BẬT. Tự ngắt tap terminal nếu nó phát quá nhiều sự kiện phím, để lỗi không thể làm treo bàn phím.";
 "Diagnostics" = "Chẩn đoán";
 "Record debug log" = "Ghi nhật ký gỡ lỗi";
-"Records tap health events in memory (never the text you type). Turn it on, reproduce the problem, then Save debug log and send us the file." = "Ghi lại các sự kiện của tap trong bộ nhớ (không ghi nội dung bạn gõ). Bật lên, tái hiện lỗi, rồi Lưu nhật ký và gửi file cho bọn mình.";
+"Records tap health events in memory (never the text you type). Turn it on, reproduce the problem, then Copy debug log and paste it into your report — or save it as a file." = "Ghi lại các sự kiện của tap trong bộ nhớ (không ghi nội dung bạn gõ). Bật lên, tái hiện lỗi, rồi bấm Chép nhật ký và dán vào báo cáo — hoặc lưu thành file.";
+"Copy debug log" = "Chép nhật ký gỡ lỗi";
 "Save debug log…" = "Lưu nhật ký gỡ lỗi…";
 "Clear" = "Xoá";
+"Copied — paste it into your bug report." = "Đã chép — dán vào phần báo lỗi.";
 "Saved to %@" = "Đã lưu vào %@";
 "Couldn’t save the file." = "Không lưu được file.";
 "Apply tone edits in Chrome and Spotlight with one Accessibility edit instead of a burst of Shift+Left key events." = "Bỏ dấu trong Chrome và Spotlight bằng một thao tác Accessibility thay vì một loạt phím Shift+Trái.";

--- a/App/Sources/SettingsWindow.swift
+++ b/App/Sources/SettingsWindow.swift
@@ -826,9 +826,10 @@ struct ExperimentalTab: View {
             }
             Section(model.loc("Diagnostics")) {
                 Toggle(model.loc("Record debug log"), isOn: $model.debugLogging)
-                Text(model.loc("Records tap health events in memory (never the text you type). Turn it on, reproduce the problem, then Save debug log and send us the file."))
+                Text(model.loc("Records tap health events in memory (never the text you type). Turn it on, reproduce the problem, then Copy debug log and paste it into your report — or save it as a file."))
                     .font(.caption).foregroundStyle(.secondary)
                 HStack {
+                    Button(model.loc("Copy debug log")) { copyLog() }
                     Button(model.loc("Save debug log…")) { saveLog() }
                     Button(model.loc("Clear")) { DebugLog.clear(); saveResult = nil }
                 }
@@ -838,6 +839,17 @@ struct ExperimentalTab: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    /// Clipboard, not a file. The report flow (BAO-LOI.md) ends with the log pasted
+    /// into a GitHub issue or a chat message, and save → find the file → attach it was
+    /// the slowest step of it — for a user who is, by definition, already annoyed.
+    /// Same snapshot as saveLog(), so a pasted log and a saved one are identical.
+    private func copyLog() {
+        let text = DebugLog.snapshot(header: debugHeader())
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        saveResult = model.loc("Copied — paste it into your bug report.")
     }
 
     private func saveLog() {

--- a/BAO-LOI.md
+++ b/BAO-LOI.md
@@ -10,7 +10,7 @@ Phiên bản, macOS, chế độ gõ… đã nằm sẵn trong nhật ký — ch
 **App / website bị lỗi:** Chrome — docs.google.com
 **Gõ chuỗi phím:** `theme ` (ghi đúng phím bấm, không phải chữ mong muốn)
 **Mong đợi:** thêm — **Thực tế:** themee
-**Nhật ký gỡ lỗi:** (kéo-thả file vào đây)
+**Nhật ký gỡ lỗi:** (dán nội dung vào đây, hoặc kéo-thả file)
 ```
 
 Lỗi hiển thị (chữ nhảy, bôi đen, mất chữ…) → kèm video quay màn hình (⌘⇧5) càng tốt.
@@ -21,6 +21,6 @@ Nhật ký chỉ ghi sự kiện của bộ gõ, **không ghi nội dung bạn g
 
 1. Menu **Ｖ** → **Cài đặt…** → tab **Tùy chỉnh** → bật **Mở tính năng nâng cao** (cuối trang).
 2. Sang tab **Thử nghiệm** → mục **Chẩn đoán** → bật **Ghi nhật ký gỡ lỗi** → bấm **Xoá**.
-3. Tái hiện lỗi trong app bị lỗi, rồi quay lại bấm **Lưu nhật ký gỡ lỗi…** ngay (log chỉ giữ 400 dòng gần nhất).
+3. Tái hiện lỗi trong app bị lỗi, rồi quay lại bấm **Chép nhật ký gỡ lỗi** ngay và dán thẳng vào issue (log chỉ giữ 2000 dòng gần nhất). Cần file thì bấm **Lưu nhật ký gỡ lỗi…**.
 
 <img src="assets/debug-log-1.png" alt="Bật Mở tính năng nâng cao" width="440"> <img src="assets/debug-log-2.png" alt="Ghi nhật ký gỡ lỗi" width="440">


### PR DESCRIPTION
Quy trình BAO-LOI.md kết thúc bằng việc dán log vào issue/chat, nhưng UI chỉ có "Lưu nhật ký gỡ lỗi…" — user phải lưu file, tìm lại file rồi đính kèm. Nút Chép dùng chung DebugLog.snapshot(header:) nên nội dung dán và file lưu giống hệt nhau.

- Caption mục Chẩn đoán hướng sang Chép trước, lưu file là lựa chọn phụ
- BAO-LOI.md bước 3: chép → dán thẳng vào issue; sửa 400 → 2000 dòng cho khớp DebugLog.capacity (đã tăng từ 2026-07-30, doc chưa cập nhật)