### PR TITLE
fix(activation): so prefix input source theo bundle id của CHÍNH build

### DIFF
--- a/App/Sources/TelexInputController.swift
+++ b/App/Sources/TelexInputController.swift
@@ -1629,12 +1629,24 @@ final class TelexInputController: IMKInputController {
     /// source of truth the flaky activate/deactivate ordering must defer to. Called
     /// only on lifecycle transitions / TIS notifications, never on the keystroke hot
     /// path, so the Carbon TIS copy is fine here. Matches both the input source and its
-    /// `.vi` input mode by bundle-id prefix.
+    /// `.vi` input mode by bundle-id prefix — THIS build's own id (see `OwnBundle`), so
+    /// a dev build registered under a separate id still recognizes itself.
     static func isVietTelexSelected() -> Bool {
         guard let src = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
               let ptr = TISGetInputSourceProperty(src, kTISPropertyInputSourceID) else { return false }
         let id = Unmanaged<CFString>.fromOpaque(ptr).takeUnretainedValue() as String
-        return id.hasPrefix("com.viettelex.inputmethod.telex")
+        return inputSourceIsOurs(id)
+    }
+
+    /// Does this input-source id belong to the RUNNING build? Split out of
+    /// `isVietTelexSelected` so the prefix rule is testable without a live TIS —
+    /// `own` is the seam a test uses to replay the dev-build id mismatch that put the
+    /// tap dormant mid-word (see `OwnBundle`). An EMPTY `own` matches nothing: bare
+    /// `hasPrefix("")` is true for every id, which would claim VietTelex is selected
+    /// while the user types in ABC. `OwnBundle` already refuses to produce one — this
+    /// is the guard at the comparison itself, where the hazard actually lives.
+    static func inputSourceIsOurs(_ id: String, own: String = OwnBundle.id) -> Bool {
+        !own.isEmpty && id.hasPrefix(own)
     }
 
     // MARK: - Input-method menu (IMK-provided, no NSStatusItem)

--- a/App/Sources/TerminalTap.swift
+++ b/App/Sources/TerminalTap.swift
@@ -24,6 +24,31 @@ import Carbon.HIToolbox
 import ApplicationServices
 import TelexCore
 
+/// THIS build's bundle id — never the ship constant hardcoded at a call site.
+/// `Scripts/dev-register.sh` installs the same code under a SEPARATE id
+/// (`com.tuanhm.inputmethod.telexdev` by default; it must be separate, see rule #4 in
+/// docs/MACOS_IME_NOTES.md), remapping CFBundleIdentifier and every TISInputSourceID.
+/// A hardcoded ship prefix therefore made `isVietTelexSelected()` answer FALSE for the
+/// dev build's own input source — so the TIS notification, the `deactivateServer`
+/// hint and the per-key reconcile all declared VietTelex unselected and put the tap
+/// DORMANT mid-word, one key at a time (tester log 2026-08-13: "biết" typed in
+/// Terminal came out "biêts" — the tone key passed through raw while the tap was
+/// dormant, and the reset that comes with dormancy also dropped the buffer, so a ⌫
+/// back to "bi" then `s` gave "bis" instead of "bí").
+///
+/// EMPTY is treated as missing, not just nil: `Bundle.bundleIdentifier` hands back
+/// whatever CFBundleIdentifier holds, and an empty prefix would make `hasPrefix`
+/// match EVERY input source — `isVietTelexSelected()` would answer true with ABC
+/// selected and the tap would compose Vietnamese over English typing, the exact
+/// failure the per-key reconcile exists to prevent. The ship id is the fallback
+/// (both states are unreachable for a correctly built bundle).
+enum OwnBundle {
+    static let id: String = {
+        let id = Bundle.main.bundleIdentifier ?? ""
+        return id.isEmpty ? "com.viettelex.inputmethod.telex" : id
+    }()
+}
+
 enum Accessibility {
     // AXIsProcessTrusted() is an out-of-process TCC check (~10-15ms when it misses
     // the kernel-side fast path); in Chromium apps it was hit up to twice per
@@ -212,7 +237,7 @@ enum Accessibility {
     /// Returns true when the reset command succeeded.
     @discardableResult
     static func resetOwnGrant() -> Bool {
-        let id = Bundle.main.bundleIdentifier ?? "com.viettelex.inputmethod.telex"
+        let id = OwnBundle.id
         var ok = false
         // Accessibility covers the tap; ListenEvent (Input Monitoring) can hold a stale
         // row of its own, and resetting a service we never used is a no-op.
@@ -287,7 +312,7 @@ final class FrontmostApp {
     /// itself — so Settings can offer "recent apps" to pin without typing a bundle id.
     /// MAIN-thread only (observer writes, Settings UI reads) — no lock needed.
     private(set) var recent: [(id: String, name: String)] = []
-    private static let selfID = "com.viettelex.inputmethod.telex"
+    private static let selfID = OwnBundle.id
 
     private init() {
         _bundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier

--- a/AppTests/OwnBundleIdentityTests.swift
+++ b/AppTests/OwnBundleIdentityTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import VietTelex
+
+// The app must recognize its OWN input source, whatever bundle id this build was
+// installed under. `Scripts/dev-register.sh` remaps every id to a separate dev
+// namespace (rule #4, docs/MACOS_IME_NOTES.md), and while the ship id was hardcoded
+// in isVietTelexSelected() the dev build answered "VietTelex is not selected" about
+// itself — so the TIS notification, deactivateServer and the per-key reconcile all
+// put the tap DORMANT mid-word. Tester log 2026-08-13: "biết" in Terminal came out
+// "biêts" (the tone key passed through raw during a dormant window), and ⌫ back to
+// "bi" then `s` gave "bis" instead of "bí" (dormancy also resets the engine).
+//
+// Everything here drives `inputSourceIsOurs` through its explicit `own:` seam. A test
+// that compared OwnBundle.id against Bundle.main would be tautological — both sides
+// read the same property, and CI builds under the ship id, so re-hardcoding that
+// literal would still pass. The prefix RULE is what these lock down.
+final class OwnBundleIdentityTests: XCTestCase {
+
+    private let ship = "com.viettelex.inputmethod.telex"
+    private let dev = "com.tuanhm.inputmethod.telexdev"
+
+    /// The regression itself: a dev build asking the SHIP prefix disowns its own input
+    /// source; asking its own id recognizes it. The ship build is unaffected.
+    func testDevBuildRecognizesItsOwnInputSource() {
+        XCTAssertFalse(TelexInputController.inputSourceIsOurs(dev + ".vi", own: ship))
+        XCTAssertTrue(TelexInputController.inputSourceIsOurs(dev + ".vi", own: dev))
+        XCTAssertTrue(TelexInputController.inputSourceIsOurs(ship + ".vi", own: ship))
+    }
+
+    /// The bundle id itself and its `.vi` input mode both match; a sibling id that
+    /// merely shares the namespace does not.
+    func testInputSourceAndModeMatchButSiblingsDoNot() {
+        XCTAssertTrue(TelexInputController.inputSourceIsOurs(ship, own: ship))
+        XCTAssertTrue(TelexInputController.inputSourceIsOurs(ship + ".vi", own: ship))
+        XCTAssertFalse(TelexInputController.inputSourceIsOurs(ship, own: dev))
+    }
+
+    func testForeignInputSourceDoesNotMatch() {
+        XCTAssertFalse(TelexInputController.inputSourceIsOurs("com.apple.keylayout.ABC"))
+        XCTAssertFalse(TelexInputController.inputSourceIsOurs("com.apple.keylayout.ABC", own: ship))
+        XCTAssertFalse(
+            TelexInputController.inputSourceIsOurs("com.apple.inputmethod.VietnameseIM.VietnameseTelex",
+                                                   own: ship))
+    }
+
+    /// An empty prefix must match NOTHING. Bare `hasPrefix("")` is true for every id,
+    /// which would report VietTelex selected while the user types in ABC and leave the
+    /// tap composing Vietnamese over English.
+    func testEmptyPrefixMatchesNothing() {
+        XCTAssertFalse(TelexInputController.inputSourceIsOurs("com.apple.keylayout.ABC", own: ""))
+        XCTAssertFalse(TelexInputController.inputSourceIsOurs(ship + ".vi", own: ""))
+    }
+
+    /// …and OwnBundle never hands one out, so the guard above is belt-and-braces.
+    func testOwnBundleIDIsNeverEmpty() {
+        XCTAssertFalse(OwnBundle.id.isEmpty)
+    }
+}


### PR DESCRIPTION
isVietTelexSelected() hardcode "com.viettelex.inputmethod.telex". dev-register.sh remap toàn bộ id sang namespace riêng (bắt buộc, rule #4 MACOS_IME_NOTES.md), nên trên bản dev hàm này LUÔN trả false — app không nhận ra chính input source của mình.

Hệ quả: cả ba đường đều tuyên bố "VietTelex không được chọn" và cho tap ngủ giữa chừng — TIS notification (main.swift), hint deactivateServer, và reconcile theo phím trong handle(). Log tester 13/08 (Terminal, bản dev):

  markInactive(stillSelected=false) → imeActive=false
  selectionChanged(isVietTelex=false) → imeActive=false
  reconcile: VietTelex not selected → tap dormant (healed stale imeActive)

Trong cửa sổ dormant, guard `imeActive` reset engine rồi cho phím đi thô:
  • "biết" → "biêts": phím tone `s` rơi đúng cửa sổ đó, xuống terminal dạng thô.
  • ⌫ về "bi" rồi `s` → "bis": buffer đã bị reset, màn hình còn "bi" nhưng engine
    rỗng nên `s` thành ký tự thường thay vì dấu sắc.
Engine hoàn toàn đúng — bieets ⌫⌫ s → "bí" đã verify trực tiếp.

Fix: OwnBundle.id lấy từ Bundle.main.bundleIdentifier, dùng chung cho isVietTelexSelected(), resetOwnGrant() và FrontmostApp.selfID (hai chỗ sau vốn đã đúng/vô hại, gom về một nguồn để không lệch lại). Bản ship không đổi hành vi: id suy ra đúng bằng hằng số cũ.

Chuỗi RỖNG bị coi như thiếu, không chỉ nil: hasPrefix("") khớp MỌI input source → sẽ báo VietTelex đang chọn trong khi user gõ ABC và tap bỏ dấu đè lên tiếng Anh. Chốt đặt ở cả OwnBundle lẫn ngay chỗ so sánh (inputSourceIsOurs), nơi mối nguy thực sự nằm.

Test: inputSourceIsOurs tách ra với seam `own:` nên pin được luật prefix mà không cần TIS sống — tránh test lặp định nghĩa (CI build bằng id ship thì test kiểu đó không bao giờ fail). Mutation-check: bỏ !own.isEmpty → testEmptyPrefixMatchesNothing fail đúng. 177 App test + 233 TelexCore test, 0 failure.