### PR TITLE
chore(github): issue form (bug/feature/question) + PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,77 @@
+name: 🐞 Báo lỗi
+description: Gõ ra chữ sai, mất chữ, chữ nhảy, không gõ được trong một app cụ thể…
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Điền đủ 4 dòng đầu **+ nhật ký gỡ lỗi** là hầu hết lỗi fix được ngay vòng đầu — thiếu nhật ký thì gần như luôn phải hỏi lại thêm một vòng.
+
+        Cách lấy nhật ký: [BAO-LOI.md](https://github.com/ptrinh/viettelex/blob/main/BAO-LOI.md#lấy-nhật-ký-gỡ-lỗi)
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Trước khi gửi
+      options:
+        - label: Đã cập nhật bản mới nhất (tab **Giới thiệu** → *Kiểm tra cập nhật*) và lỗi vẫn còn
+          required: true
+        - label: Đã tìm trong [các issue đang mở](https://github.com/ptrinh/viettelex/issues) và không thấy trùng
+          required: true
+
+  - type: input
+    id: app
+    attributes:
+      label: App / website bị lỗi
+      description: Nếu là browser, ghi cả tên website — cơ chế gõ khác nhau giữa address bar và nội dung trang.
+      placeholder: Chrome — docs.google.com
+    validations:
+      required: true
+
+  - type: input
+    id: keys
+    attributes:
+      label: Gõ chuỗi phím
+      description: Ghi đúng **phím bấm**, không phải chữ mong muốn.
+      placeholder: "theme "
+    validations:
+      required: true
+
+  - type: input
+    id: expected
+    attributes:
+      label: Mong đợi
+      placeholder: thêm
+    validations:
+      required: true
+
+  - type: input
+    id: actual
+    attributes:
+      label: Thực tế
+      placeholder: themee
+    validations:
+      required: true
+
+  - type: textarea
+    id: log
+    attributes:
+      label: Nhật ký gỡ lỗi
+      description: |
+        Tab **Thử nghiệm** → **Chẩn đoán** → bật **Ghi nhật ký gỡ lỗi** → **Xoá** → tái hiện lỗi → **Chép nhật ký gỡ lỗi** → dán vào đây (log chỉ giữ 2000 dòng gần nhất).
+
+        Nhật ký chỉ ghi sự kiện của bộ gõ, **không ghi nội dung bạn gõ** — và đã có sẵn phiên bản, macOS, cơ chế gõ nên bạn không cần điền tay.
+      render: text
+
+  - type: input
+    id: version
+    attributes:
+      label: Phiên bản VietTelex + macOS
+      description: Chỉ cần điền nếu **không** kèm nhật ký ở trên.
+      placeholder: 1.5.10 — macOS 26.1
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Thông tin thêm
+      description: Lỗi hiển thị (chữ nhảy, bôi đen, mất chữ…) → kèm video quay màn hình (⌘⇧5) càng tốt. Kéo-thả file vào đây.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# Tắt issue trắng: mẫu 🐞 Báo lỗi ép điền đúng những field mà BAO-LOI.md yêu cầu
+# (app/website, chuỗi phím, mong đợi/thực tế, nhật ký) — thiếu chúng thì mỗi report
+# mất thêm một vòng hỏi lại. Mẫu ❓ Câu hỏi là cửa cho mọi thứ không vừa 2 mẫu kia
+# (repo không bật Discussions), nên không ai bị chặn khi cần hỏi.
+blank_issues_enabled: false
+
+contact_links:
+  - name: 📋 Hướng dẫn báo lỗi + cách lấy nhật ký gỡ lỗi
+    url: https://github.com/ptrinh/viettelex/blob/main/BAO-LOI.md
+    about: Đọc trước khi mở issue lỗi — kèm nhật ký thì lỗi thường fix được ngay vòng đầu.
+  - name: 🛠 Khắc phục sự cố thường gặp
+    url: https://github.com/ptrinh/viettelex#khắc-phục-sự-cố
+    about: Không thấy trong Input Sources, không gõ được trong Terminal/Chrome, gõ bị lặp chữ…
+  - name: ⌨️ App gõ sai cơ chế? Mở PR thêm một dòng rule
+    url: https://github.com/ptrinh/viettelex/blob/main/typing-modes.yml
+    about: "Thêm `bundle-id: mode` vào typing-modes.yml — cách đóng góp không cần sửa Swift."

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,40 @@
+name: 💡 Đề xuất tính năng
+description: Ý tưởng cải thiện cách gõ, Cài đặt, hoặc trải nghiệm
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Triết lý của VietTelex: **tối giản, nhanh, ổn định** — cài xong là gõ, hầu như không phải chỉnh gì. Đề xuất giữ được điều đó (không thêm tuỳ chọn cho một trường hợp riêng lẻ) sẽ dễ được nhận hơn.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Trước khi gửi
+      options:
+        - label: Đã xem qua **Cài đặt…** (tab **Tùy chỉnh** và **Thử nghiệm**) — tính năng này chưa có
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Vấn đề bạn đang gặp
+      description: Mô tả tình huống gõ thật, không phải giải pháp. Càng cụ thể (app nào, chuỗi phím nào) càng dễ đánh giá.
+      placeholder: |
+        Gõ tên biến code trong Slack thì bị bỏ dấu nhầm, phải tắt bộ gõ mỗi lần.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Đề xuất
+      description: Bạn muốn app hành xử thế nào? Nếu là tuỳ chọn mới, mặc định nên bật hay tắt?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Hiện tại bạn đang xoay xở thế nào
+      description: Cách làm tạm, tuỳ chọn đã thử, hoặc bộ gõ khác làm việc này ra sao.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,34 @@
+name: ❓ Câu hỏi / góp ý khác
+description: Không chắc là lỗi, hỏi cách dùng, hoặc góp ý chung
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Nếu app gõ ra chữ sai thì dùng mẫu **🐞 Báo lỗi** — sẽ được xử lý nhanh hơn nhiều.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Trước khi gửi
+      options:
+        - label: Đã đọc [Khắc phục sự cố](https://github.com/ptrinh/viettelex#khắc-phục-sự-cố) trong README
+          required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Câu hỏi
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Phiên bản VietTelex + macOS
+      placeholder: 1.5.10 — macOS 26.1
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: Bạn đã thử những gì

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!-- Xoá phần nào không liên quan. Mục tiêu: reviewer hiểu được thay đổi mà không phải đọc hết diff. -->
+
+## Thay đổi gì
+
+<!-- Một hai câu: hành vi TRƯỚC → SAU. Nếu fix lỗi đã có issue: `Closes #NN`. -->
+
+## Loại thay đổi
+
+- [ ] Rule cơ chế gõ (`typing-modes.yml`)
+- [ ] Engine / validator (`TelexCore/`)
+- [ ] App: routing per-app, IMKit, CGEventTap, Settings UI (`App/Sources/`)
+- [ ] Tài liệu (`docs/`, `README.md`, `BAO-LOI.md`)
+- [ ] Khác:
+
+## Đã test
+
+- [ ] `cd TelexCore && swift test` xanh
+- [ ] Có golden test cho hành vi mới trong `EngineTests.swift` (bắt buộc khi sửa engine)
+- [ ] `swift test -c release --filter 'Benchmark|ZeroAllocation'` xanh — hot path không cấp phát heap
+- [ ] Đã cài lên máy thật (`Scripts/dev-install.sh`) và gõ thử trong app bị ảnh hưởng, theo [`docs/checklist.md`](https://github.com/ptrinh/viettelex/blob/main/docs/checklist.md)
+
+Máy đã test: <!-- ví dụ: macOS 26.1, MacBook Pro M2, VietTelex 1.5.10 -->
+
+## Nếu PR thêm/sửa rule `typing-modes.yml`
+
+- Bundle id: `` <!-- lấy bằng: osascript -e 'id of app "Tên app"' -->
+- Mode chọn: `` — mode cũ (hoặc auto-probe) sai thế nào:
+- [ ] Đã test cả **biên**, không chỉ giữa dòng: đầu dòng, đầu message/ô, giữa từ, `⌫` giữa từ
+- [ ] Comment (nếu có) nằm **riêng một dòng** — parser không đọc được comment cùng dòng với rule
+
+## Ghi chú cho reviewer
+
+<!-- Ảnh/video nếu đụng UI. Chỗ nào bạn muốn được soi kỹ? Đánh đổi nào đã chọn? -->

--- a/BAO-LOI.md
+++ b/BAO-LOI.md
@@ -1,10 +1,10 @@
 # Báo lỗi VietTelex
 
-Gửi issue tại **https://github.com/ptrinh/viettelex/issues/new**. Trước khi báo: cập nhật bản mới nhất (tab **Giới thiệu** → *Kiểm tra cập nhật*) và thử lại.
+Gửi issue tại **https://github.com/ptrinh/viettelex/issues/new/choose** → chọn **🐞 Báo lỗi**. Trước khi báo: cập nhật bản mới nhất (tab **Giới thiệu** → *Kiểm tra cập nhật*) và thử lại.
 
 ## Mẫu issue
 
-Phiên bản, macOS, chế độ gõ… đã nằm sẵn trong nhật ký — chỉ cần điền:
+Form sẽ hỏi đúng những field dưới đây — xem trước cho nhanh. Phiên bản, macOS, chế độ gõ… đã nằm sẵn trong nhật ký:
 
 ```markdown
 **App / website bị lỗi:** Chrome — docs.google.com


### PR DESCRIPTION
BAO-LOI.md mô tả đúng những field cần cho một report fix được ngay vòng đầu, nhưng không có gì ép người báo điền chúng — thiếu chuỗi phím hoặc nhật ký thì mỗi issue mất thêm một vòng hỏi lại. Issue form đưa chính những field đó thành input required.

- bug.yml: app/website (nhắc ghi cả website — browser routing khác nhau giữa address bar và page content), chuỗi phím, mong đợi/thực tế đều required; nhật ký render: text (GitHub không cho required cùng render); phiên bản + macOS chỉ cần khi không kèm nhật ký.
- feature.yml: hỏi vấn đề TRƯỚC đề xuất, để đánh giá được theo triết lý tối giản.
- question.yml: repo không bật Discussions, nên cần một cửa cho phần không vừa hai mẫu kia — có nó mới tắt được issue trắng mà không chặn ai.
- config.yml: blank_issues_enabled: false + link BAO-LOI / Khắc phục sự cố / typing-modes.yml.
- Chỉ dùng label đã có upstream (bug/enhancement/question).

PR template: checklist test lấy từ docs/CONTRIBUTE.md, thêm section riêng cho PR rule typing-modes.yml — bắt buộc test BIÊN (đầu dòng, đầu message/ô, giữa từ, ⌫), đúng lớp lỗi Lark/Discord ghi trong header file, và nhắc comment phải nằm riêng dòng.

BAO-LOI.md: link → /issues/new/choose, block mẫu thành "xem trước" thay vì copy-paste, để hai chỗ không lệch nhau.