### PR TITLE
test(terminal): automate issue #33 regression corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: swift test
         run: cd TelexCore && swift test
+      - name: Terminal harness unit tests
+        run: |
+          python3 -m unittest Scripts/test_pty_reader.py
+          python3 -m json.tool Scripts/terminal-regression-cases.json >/dev/null
+          swiftc -typecheck Scripts/stress-typing.swift
       - name: Benchmarks + zero-alloc (release)
         run: cd TelexCore && swift test -c release --filter 'Benchmark|ZeroAllocation'
 

--- a/Scripts/pty-reader.py
+++ b/Scripts/pty-reader.py
@@ -5,19 +5,115 @@
 # (pty-poster.swift, DispatchTime.uptimeNanoseconds) stamps with, so the two
 # logs subtract directly with no cross-clock skew.
 #
-# Usage:  python3 pty-reader.py /tmp/pty-arrivals.log   (Ctrl-C or 'q' to stop)
-import sys, tty, termios, time, os
+# Usage:
+#   python3 pty-reader.py /tmp/pty-arrivals.log
+#   python3 pty-reader.py /tmp/pty-arrivals.log \
+#       --corpus Scripts/terminal-regression-cases.json --repeats 10
+import argparse
+import codecs
+import json
+import os
+import sys
+import termios
+import time
+import tty
 
-log = open(sys.argv[1], "w", buffering=1)
-fd = sys.stdin.fileno()
-old = termios.tcgetattr(fd)
-try:
-    tty.setraw(fd)
-    while True:
-        b = os.read(fd, 1)
-        t = time.clock_gettime_ns(time.CLOCK_UPTIME_RAW)
-        if not b or b == b"q":
-            break
-        log.write(f"{t} {b.hex()}\n")
-finally:
-    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+class TerminalLine:
+    """Reconstruct visible text from raw terminal bytes."""
+
+    def __init__(self):
+        self.characters = []
+        self.decoder = codecs.getincrementaldecoder("utf-8")("strict")
+        self.last_was_carriage_return = False
+
+    def feed(self, byte):
+        if byte == b"\n" and self.last_was_carriage_return:
+            self.last_was_carriage_return = False
+            return None
+        self.last_was_carriage_return = byte == b"\r"
+        if byte in (b"\x08", b"\x7f"):
+            self.decoder.reset()
+            if self.characters:
+                self.characters.pop()
+            return None
+        if byte in (b"\r", b"\n"):
+            self.decoder.reset()
+            line = "".join(self.characters)
+            self.characters.clear()
+            return line
+        decoded = self.decoder.decode(byte)
+        if decoded:
+            self.characters.extend(decoded)
+        return None
+
+
+def load_expected(corpus_path, repeats):
+    with open(corpus_path, encoding="utf-8") as handle:
+        cases = json.load(handle)
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("corpus must be a non-empty JSON array")
+    expected = []
+    for _ in range(repeats):
+        for case in cases:
+            if not isinstance(case, dict) or not case.get("name") or "expected" not in case:
+                raise ValueError("every corpus case needs name and expected")
+            expected.append((case["name"], case["expected"]))
+    return expected
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log")
+    parser.add_argument("--corpus")
+    parser.add_argument("--repeats", type=int, default=1)
+    args = parser.parse_args(argv)
+    if args.repeats < 1:
+        parser.error("--repeats must be greater than zero")
+    return args
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    expected = load_expected(args.corpus, args.repeats) if args.corpus else None
+    failures = 0
+    completed = 0
+    state = TerminalLine()
+    with open(args.log, "w", buffering=1) as log:
+        fd = sys.stdin.fileno()
+        old = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            while True:
+                byte = os.read(fd, 1)
+                timestamp = time.clock_gettime_ns(time.CLOCK_UPTIME_RAW)
+                if not byte or byte == b"\x03" or (expected is None and byte == b"q"):
+                    break
+                log.write(f"{timestamp} {byte.hex()}\n")
+                line = state.feed(byte)
+                if line is None or expected is None:
+                    continue
+                name, wanted = expected[completed]
+                completed += 1
+                if line == wanted:
+                    print(f"PASS {completed}/{len(expected)} {name}: {line!r}")
+                else:
+                    failures += 1
+                    print(
+                        f"FAIL {completed}/{len(expected)} {name}: "
+                        f"expected {wanted!r}, received {line!r}"
+                    )
+                if completed == len(expected):
+                    break
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    if expected is not None:
+        if completed != len(expected):
+            print(f"FAIL incomplete: received {completed}/{len(expected)} cases")
+            return 1
+        print(f"Result: {len(expected) - failures}/{len(expected)} passed")
+    return int(failures != 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/stress-typing.swift
+++ b/Scripts/stress-typing.swift
@@ -7,6 +7,8 @@
 //
 // Usage:
 //   swift Scripts/stress-typing.swift [keys_per_sec=500] [repeats=20]
+//   swift Scripts/stress-typing.swift --corpus Scripts/terminal-regression-cases.json \
+//       [--rate 7] [--repeats 10]
 //   → focus vào ô text đích trong 3s countdown; script gõ câu Telex chuẩn
 //     lặp lại, in ra văn bản KỲ VỌNG để so sánh mắt thường / diff.
 //
@@ -15,12 +17,50 @@
 import Cocoa
 
 let args = CommandLine.arguments
-let rate = args.count > 1 ? Double(args[1]) ?? 500 : 500
-let repeats = args.count > 2 ? Int(args[2]) ?? 20 : 20
+
+struct TerminalCase: Codable {
+    let name: String
+    let keys: String
+    let expected: String
+}
+
+func value(after flag: String) -> String? {
+    guard let index = args.firstIndex(of: flag), index + 1 < args.count else { return nil }
+    return args[index + 1]
+}
+
+let corpusPath = value(after: "--corpus")
+let rate = value(after: "--rate").flatMap(Double.init)
+    ?? (corpusPath == nil && args.count > 1 ? Double(args[1]) : nil)
+    ?? 500
+let repeats = value(after: "--repeats").flatMap(Int.init)
+    ?? (corpusPath == nil && args.count > 2 ? Int(args[2]) : nil)
+    ?? 20
+
+guard rate > 0, repeats > 0 else {
+    fputs("rate and repeats must be greater than zero\n", stderr)
+    exit(2)
+}
 
 // Câu test chuẩn của checklist + kỳ vọng sau khi engine xử lý.
 let telexKeys = "ddaay laf tieengs vieejt raats hay "
 let expected  = "đây là tiếng việt rất hay "
+let cases: [TerminalCase]
+if let corpusPath {
+    do {
+        let data = try Data(contentsOf: URL(fileURLWithPath: corpusPath))
+        cases = try JSONDecoder().decode([TerminalCase].self, from: data)
+    } catch {
+        fputs("cannot load corpus \(corpusPath): \(error)\n", stderr)
+        exit(2)
+    }
+    guard !cases.isEmpty, cases.allSatisfy({ !$0.name.isEmpty && !$0.keys.isEmpty }) else {
+        fputs("corpus must contain named, non-empty cases\n", stderr)
+        exit(2)
+    }
+} else {
+    cases = [TerminalCase(name: "legacy-stress", keys: telexKeys, expected: expected)]
+}
 
 // US-layout virtual keycodes cho a-z + space.
 let keycode: [Character: CGKeyCode] = [
@@ -37,22 +77,41 @@ func post(_ ch: Character) {
     CGEvent(keyboardEventSource: src, virtualKey: k, keyDown: false)?.post(tap: .cghidEventTap)
 }
 
+func postEnter() {
+    let enter: CGKeyCode = 36
+    CGEvent(keyboardEventSource: src, virtualKey: enter, keyDown: true)?.post(tap: .cghidEventTap)
+    CGEvent(keyboardEventSource: src, virtualKey: enter, keyDown: false)?.post(tap: .cghidEventTap)
+}
+
 let gap = 1.0 / rate
-print("Sẽ gõ \(repeats) lần @ \(Int(rate)) phím/s (\(telexKeys.count * repeats) phím).")
+let keysPerPass = cases.reduce(0) { $0 + $1.keys.count }
+let boundaryKeys = corpusPath == nil ? 0 : cases.count
+let totalKeys = (keysPerPass + boundaryKeys) * repeats
+print("Sẽ gõ \(repeats) vòng × \(cases.count) ca @ \(rate) phím/s (\(totalKeys) phím).")
 print("Focus vào ô text đích... 3s")
 Thread.sleep(forTimeInterval: 3)
 
 let t0 = DispatchTime.now().uptimeNanoseconds
 for _ in 0..<repeats {
-    for ch in telexKeys {
-        post(ch)
-        Thread.sleep(forTimeInterval: gap)
+    for testCase in cases {
+        for ch in testCase.keys {
+            post(ch)
+            Thread.sleep(forTimeInterval: gap)
+        }
+        if corpusPath != nil {
+            postEnter()
+            Thread.sleep(forTimeInterval: gap)
+        }
     }
 }
 let secs = Double(DispatchTime.now().uptimeNanoseconds - t0) / 1_000_000_000
 
 print(String(format: "\nXong: %d phím trong %.1fs (%.0f phím/s thực tế).",
-             telexKeys.count * repeats, secs, Double(telexKeys.count * repeats) / secs))
-print("\nVăn bản KỲ VỌNG (lặp \(repeats) lần):")
-print(String(repeating: expected, count: repeats))
-print("\nSo với văn bản thực tế trong app: không được mất/lặp/sai dấu ký tự nào.")
+             totalKeys, secs, Double(totalKeys) / secs))
+if corpusPath == nil {
+    print("\nVăn bản KỲ VỌNG (lặp \(repeats) lần):")
+    print(String(repeating: expected, count: repeats))
+    print("\nSo với văn bản thực tế trong app: không được mất/lặp/sai dấu ký tự nào.")
+} else {
+    print("\nReader sẽ tự đối chiếu \(cases.count * repeats) dòng với corpus.")
+}

--- a/Scripts/terminal-regression-cases.json
+++ b/Scripts/terminal-regression-cases.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "baseline",
+    "keys": "ddaay laf tieengs vieejt raats hay",
+    "expected": "đây là tiếng việt rất hay"
+  },
+  {
+    "name": "issue-33-huynh-van-bach",
+    "keys": "huynhf vawn bachs",
+    "expected": "huỳnh văn bách"
+  },
+  {
+    "name": "issue-33-final-tone-keys",
+    "keys": "phari gox mowsi ra",
+    "expected": "phải gõ mới ra"
+  }
+]

--- a/Scripts/test_pty_reader.py
+++ b/Scripts/test_pty_reader.py
@@ -1,0 +1,57 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("pty-reader.py")
+SPEC = importlib.util.spec_from_file_location("pty_reader", MODULE_PATH)
+pty_reader = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(pty_reader)
+
+
+class TerminalLineTests(unittest.TestCase):
+    def test_reconstructs_backspace_and_multibyte_replacement(self):
+        state = pty_reader.TerminalLine()
+        lines = []
+        for byte in b"a\x7f" + "á".encode() + b"\r":
+            line = state.feed(bytes([byte]))
+            if line is not None:
+                lines.append(line)
+        self.assertEqual(lines, ["á"])
+
+    def test_backspace_at_start_is_safe(self):
+        state = pty_reader.TerminalLine()
+        self.assertIsNone(state.feed(b"\x7f"))
+        self.assertEqual(state.feed(b"\r"), "")
+
+    def test_crlf_is_one_line_boundary(self):
+        state = pty_reader.TerminalLine()
+        lines = []
+        for byte in b"first\r\nsecond\n":
+            line = state.feed(bytes([byte]))
+            if line is not None:
+                lines.append(line)
+        self.assertEqual(lines, ["first", "second"])
+
+    def test_load_expected_repeats_corpus_in_order(self):
+        with tempfile.TemporaryDirectory() as directory:
+            corpus = Path(directory) / "cases.json"
+            corpus.write_text(
+                json.dumps(
+                    [
+                        {"name": "a", "keys": "as", "expected": "á"},
+                        {"name": "b", "keys": "dd", "expected": "đ"},
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                pty_reader.load_expected(corpus, 2),
+                [("a", "á"), ("b", "đ"), ("a", "á"), ("b", "đ")],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -75,6 +75,28 @@ Ma trận test tay theo app. Trạng thái: ☐ chưa test / ✅ pass / ❌ fail
 
 1. **`insertText(replacementRange:)` né được lớp lỗi lớn nhất** ("dđ" trong omnibox/Excel — race giữa backspace và inline autocomplete), nhưng phải test theo version Chromium.
 2. **Fallback tap-mode là bắt buộc**: Terminal/TUI và app bỏ qua replacementRange. Probe read-back tự phát hiện, không bắt user cấu hình.
+
+### Terminal/TUI regression tự động
+
+Issue #33 có lỗi dấu cuối từ không ổn định trong Claude/Kiro CLI ở tốc độ gõ
+bình thường. Chạy reader ở terminal thứ nhất:
+
+```bash
+python3 Scripts/pty-reader.py /tmp/viettelex-terminal.log \
+  --corpus Scripts/terminal-regression-cases.json --repeats 10
+```
+
+Ở terminal thứ hai, chạy poster rồi focus lại terminal reader trong 3 giây:
+
+```bash
+swift Scripts/stress-typing.swift \
+  --corpus Scripts/terminal-regression-cases.json --rate 7 --repeats 10
+```
+
+Reader tự áp dụng byte Backspace/DEL và decode UTF-8 để dựng text mà TUI thật
+nhận được, sau đó so sánh từng dòng. Kết quả phải là `30/30 passed`. Chạy lại
+với `--rate 500` để giữ stress coverage cũ. Corpus gồm baseline và hai chuỗi
+tái hiện từ issue #33; thêm case mới vào JSON, không hardcode thêm trong script.
 3. **Electron hỏng Ở BIÊN TỪ** dù giữa dòng trông ổn — mọi test in-place cho app Electron phải gõ đầu-dòng/đầu-message trước khi kết luận.
 4. **Secure input**: check `IsSecureEventInputEnabled`, bypass sạch.
 5. **VS Code EditContext** là chiến trường mới — theo dõi khi nó thành default upstream (hiện VietTelex đi tap nên không blocker).


### PR DESCRIPTION
## Thay đổi gì

Biến stress script terminal hiện có thành harness corpus-driven có thể tự đối chiếu byte stream mà TUI nhận được, thay vì chỉ gõ một câu hardcode rồi so sánh bằng mắt. Corpus ban đầu chứa đúng hai chuỗi được báo trong #33 cùng một baseline.

Reader giữ log timestamp cũ, đồng thời dựng lại dòng hiển thị từ UTF-8 + Backspace/DEL, báo PASS/FAIL từng case và trả exit code khác 0 khi sai hoặc thiếu dòng. Chế độ stress positional cũ vẫn giữ nguyên.

Refs #33.

## Loại thay đổi

- [ ] Rule cơ chế gõ (`typing-modes.yml`)
- [ ] Engine / validator (`TelexCore/`)
- [ ] App: routing per-app, IMKit, CGEventTap, Settings UI (`App/Sources/`)
- [x] Tài liệu (`docs/`, `README.md`, `BAO-LOI.md`)
- [x] Khác: terminal regression harness + CI unit tests

## Đã test

- [x] `cd TelexCore && swift test` xanh — 233 tests, 3 release-only skips
- [ ] Có golden test cho hành vi mới trong `EngineTests.swift` — không sửa engine
- [x] `swift test -c release --filter 'Benchmark|ZeroAllocation'` xanh — 7/7
- [ ] Đã cài lên máy thật và gõ thử trong app bị ảnh hưởng — harness cần maintainer/reporter chạy với VietTelex đang active trong terminal tái hiện được lỗi

Máy đã test: macOS 26 beta, Apple Silicon, Xcode-beta Swift toolchain

Kiểm tra thêm:

- `python3 -m unittest Scripts/test_pty_reader.py` — 4/4
- `python3 -m py_compile Scripts/pty-reader.py Scripts/test_pty_reader.py`
- `swiftc -typecheck Scripts/stress-typing.swift`
- corpus JSON parse + `git diff --check`

## Ghi chú cho reviewer

PR này tạo reproduction/regression gate có thể đo được cho #33; nó không khẳng định đã sửa root cause của IME. Nhờ maintainer hoặc reporter chạy hai-terminal workflow trong `docs/checklist.md` ở tốc độ 7 phím/s và 500 phím/s trên terminal từng tái hiện lỗi.

Điểm nên soi kỹ: reader coi CRLF là một boundary, xử lý DEL/Backspace theo Unicode character, và chỉ dùng `q` để thoát ở legacy log-only mode để corpus có thể chứa chữ `q`.
