### PR TITLE
feat(updater): hiển thị changelog lấy từ GitHub cho cả hai kênh cập nhật

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -14,6 +14,10 @@ Press “Repair automatically”: VietTelex removes its own stuck entry and asks
 
 "Open Accessibility Settings" = "Open Accessibility Settings";
 
+"What’s new" = "What’s new";
+
+"Full changelog" = "Full changelog";
+
 "Update now" = "Update now";
 
 "Update now body" = "Update now downloads the new version, verifies its signature and swaps it in automatically — no password needed. The input method restarts when done.";

--- a/App/Resources/vi.lproj/Localizable.strings
+++ b/App/Resources/vi.lproj/Localizable.strings
@@ -44,6 +44,8 @@
 "Download update…" = "Tải bản mới…";
 "You’re up to date (%@)." = "Đã là bản mới nhất (%@).";
 "Update available: %@" = "Có bản mới: %@";
+"What’s new" = "Có gì mới";
+"Full changelog" = "Xem đầy đủ thay đổi";
 "Couldn’t check — %@." = "Không kiểm tra được — %@.";
 
 /* Shortcuts tab */

--- a/App/Sources/SettingsWindow.swift
+++ b/App/Sources/SettingsWindow.swift
@@ -30,7 +30,13 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             let win = NSWindow(contentViewController: hosting)
             win.title = VTLocalized("VietTelex — Settings")
             win.styleMask = [.titled, .closable, .miniaturizable, .resizable]
-            win.setContentSize(NSSize(width: 680, height: 560))
+            // 660, not the old 560: the About tab has no scroll container, and at 560 its
+            // fixed content (icon + links + update block + copyright) already consumed the
+            // full height once padding and the tab bar came out. The changelog box added
+            // there is the only compressible child, so it absorbed the whole deficit and
+            // collapsed to a sliver. Height is a first-creation default — users who resized
+            // keep their own frame.
+            win.setContentSize(NSSize(width: 680, height: 660))
             win.contentMinSize = NSSize(width: 640, height: 500)
             win.delegate = self
             win.isReleasedWhenClosed = false
@@ -998,6 +1004,12 @@ struct AboutTab: View {
     /// Set only when a newer release exists — the version the button will install.
     /// (No URL state: SelfUpdater's own failure alert offers the releases page.)
     @State private var updateVersion: String?
+    /// Changelog for `updateVersion`, PARSED once at assignment rather than held as raw
+    /// Markdown: `body` re-runs on every `model` publish and on each checking/installing/
+    /// status flip, and re-splitting a 4000-character release body inside `ForEach` on
+    /// every one of those is work with no reason to repeat. Empty = no notes to show
+    /// (release had no body, or GitHub couldn't be reached for it).
+    @State private var noteBlocks: [UpdateCheck.NoteBlock] = []
     @State private var installing = false
 
     var body: some View {
@@ -1047,6 +1059,12 @@ struct AboutTab: View {
                     Text(status).font(.caption).foregroundStyle(.secondary)
                         .lineLimit(2).multilineTextAlignment(.center)
                 }
+                // "Update available: 1.6.3" alone asks the user to install on faith. The
+                // release body answers what changed — same box for both channels, since
+                // the weekly check now stores its notes too (Updater.swift).
+                if !noteBlocks.isEmpty {
+                    releaseNotesBox()
+                }
                 // Opt-in weekly auto-check (default OFF): the toggle IS the user's
                 // consent, so the "no network unless you ask" stance holds.
                 Toggle(model.loc("Check weekly and notify me"), isOn: $model.autoUpdateCheck)
@@ -1073,14 +1091,70 @@ struct AboutTab: View {
             if status == nil, updateVersion == nil,
                let pending = UpdateCheck.pendingUpdateVersion {
                 updateVersion = pending
+                noteBlocks = UpdateCheck.pendingUpdateNotes.map(UpdateCheck.noteBlocks) ?? []
                 status = String(format: model.loc("Update available: %@"), pending)
             }
         }
     }
 
+    /// The changelog, rendered from the release body's Markdown. Scrolls rather than
+    /// stretching the window: a release can have three bullets or thirty, and the About
+    /// tab keeps its shape either way.
+    @ViewBuilder
+    private func releaseNotesBox() -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(model.loc("What’s new")).font(.caption).bold()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 5) {
+                    ForEach(noteBlocks) { block in
+                        switch block.kind {
+                        case .heading:
+                            Text(inlineMarkdown(block.text)).font(.caption).bold()
+                        case .bullet:
+                            // Hanging indent: the marker sits outside the text column so
+                            // wrapped lines line up under the first word, not the bullet.
+                            HStack(alignment: .firstTextBaseline, spacing: 5) {
+                                Text("•").font(.caption).foregroundStyle(.secondary)
+                                Text(inlineMarkdown(block.text)).font(.caption)
+                            }
+                        case .paragraph:
+                            Text(inlineMarkdown(block.text)).font(.caption)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(6)
+            }
+            .frame(maxHeight: 140)
+            .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 6))
+            // Long bodies are cut at notesCharacterCap, and a body can also out-scroll the
+            // box — either way the release page is where the rest lives. Derived from the
+            // version, so the weekly channel (which persists no URL) gets the link too.
+            if let updateVersion, let full = UpdateCheck.releasePageURL(forVersion: updateVersion) {
+                Link(model.loc("Full changelog"), destination: full).font(.caption2)
+            }
+        }
+        .frame(maxWidth: 380)
+        .padding(.top, 2)
+        // The About tab has no scroll container: without this the box is the only
+        // compressible child and takes the whole squeeze when the window is short.
+        .layoutPriority(1)
+    }
+
+    /// `Text` interprets inline Markdown only, and only via AttributedString — bold, code
+    /// spans and links survive; anything it can't parse falls back to the raw line rather
+    /// than disappearing.
+    private func inlineMarkdown(_ s: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: s,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(s)
+    }
+
     private func runCheck() {
-        checking = true; status = nil; updateVersion = nil
+        checking = true; status = nil; updateVersion = nil; noteBlocks = []
         UpdateCheck.pendingUpdateVersion = nil   // the user is looking; this is now live state
+        UpdateCheck.pendingUpdateNotes = nil
         Task {
             let outcome = await UpdateCheck.check()
             await MainActor.run {
@@ -1088,9 +1162,10 @@ struct AboutTab: View {
                 switch outcome {
                 case .upToDate(let v):
                     status = String(format: model.loc("You’re up to date (%@)."), v)
-                case .update(let latest, _):
+                case .update(let latest, _, let notes):
                     status = String(format: model.loc("Update available: %@"), latest)
                     updateVersion = latest
+                    noteBlocks = notes.map(UpdateCheck.noteBlocks) ?? []
                 case .failed(let e):
                     status = String(format: model.loc("Couldn’t check — %@."), e)
                 }

--- a/App/Sources/Updater.swift
+++ b/App/Sources/Updater.swift
@@ -20,6 +20,15 @@ enum UpdateCheck {
         get { notifyDefaults.string(forKey: "pendingUpdateVersion").flatMap { $0.isEmpty ? nil : $0 } }
         set { notifyDefaults.set(newValue ?? "", forKey: "pendingUpdateVersion") }
     }
+
+    /// Changelog for `pendingUpdateVersion`, persisted for the same reason it is: the
+    /// weekly check and the About-tab visit are separated by an IME relaunch, and
+    /// re-fetching on `onAppear` would put the network back on a path the user never
+    /// clicked. Always written and cleared together with the version above.
+    nonisolated(unsafe) static var pendingUpdateNotes: String? {
+        get { notifyDefaults.string(forKey: "pendingUpdateNotes").flatMap { $0.isEmpty ? nil : $0 } }
+        set { notifyDefaults.set(newValue ?? "", forKey: "pendingUpdateNotes") }
+    }
     // Same suite AppState uses — including the XCTest isolation (see settingsSuiteName).
     private static let notifyDefaults = UserDefaults(suiteName: AppState.settingsSuiteName) ?? .standard
 
@@ -39,13 +48,15 @@ enum UpdateCheck {
         guard now - AppState.shared.lastAutoUpdateCheckAt > 7 * 24 * 3600 else { return }
         AppState.shared.lastAutoUpdateCheckAt = now
         Task {
-            guard case let .update(latest, _) = await checkStable() else { return }
+            guard case let .update(latest, _, notes) = await checkStable() else { return }
             await MainActor.run {
                 guard AppState.shared.lastNotifiedUpdateVersion != latest else { return }
                 AppState.shared.lastNotifiedUpdateVersion = latest
                 // Always record it first: the About tab shows this even if the banner
-                // never appears (permission denied / Do Not Disturb).
+                // never appears (permission denied / Do Not Disturb). The notes ride
+                // along so that surface can answer "what changed?", not just "something did".
                 pendingUpdateVersion = latest
+                pendingUpdateNotes = notes
                 UpdateNotifier.post(version: latest)
             }
         }
@@ -55,7 +66,9 @@ enum UpdateCheck {
 
     enum Outcome {
         case upToDate(String)                       // current == latest
-        case update(latest: String, url: URL)       // a newer release exists
+        /// `notes` is the release body (Markdown), already sanitized — nil when GitHub
+        /// had none or the fetch failed. Never a reason to fail the whole check.
+        case update(latest: String, url: URL, notes: String?)
         case failed(String)                         // network / parse error
     }
 
@@ -82,11 +95,79 @@ enum UpdateCheck {
                   let stable = obj["version"] as? String else { return .failed("dữ liệu lạ") }
             let pageURL = (obj["url"] as? String).flatMap(URL.init(string:))
                 ?? URL(string: "https://github.com/\(repo)/releases/latest")!
-            return isNewer(stable, than: current) ? .update(latest: stable, url: pageURL)
-                                                  : .upToDate(current)
+            guard isNewer(stable, than: current) else { return .upToDate(current) }
+            // The manifest deliberately stays two lines the maintainer hand-edits, so the
+            // changelog is read from the release that tag already points at — one source of
+            // truth (the GitHub release body), no second thing to remember at promote time.
+            return .update(latest: stable, url: pageURL,
+                           notes: await releaseNotes(forVersion: stable))
         } catch {
             return .failed(error.localizedDescription)
         }
+    }
+
+    /// The release body for one version's tag (`v1.6.3`), used by the STABLE channel —
+    /// `/releases/latest` hands its body over for free, but `stable.json` only names a
+    /// version, so that channel has to ask for the tag by name.
+    ///
+    /// Best-effort by construction: every failure path returns nil rather than throwing,
+    /// because a missing changelog must never turn a real update into `.failed`. The
+    /// version number is the news; the notes are the courtesy.
+    static func releaseNotes(forVersion version: String) async -> String? {
+        guard let api = URL(string: "https://api.github.com/repos/\(repo)/releases/tags/v\(version)")
+        else { return nil }
+        var req = URLRequest(url: api, timeoutInterval: 12)
+        req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        req.setValue("VietTelex/\(currentVersion())", forHTTPHeaderField: "User-Agent")
+        guard let (data, resp) = try? await URLSession.shared.data(for: req),
+              (resp as? HTTPURLResponse)?.statusCode == 200,
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return sanitizeNotes(obj["body"] as? String)
+    }
+
+    /// Longest changelog we will render. The About tab is a 640pt window, not a browser;
+    /// past this the "Full changelog" link is the better answer.
+    static let notesCharacterCap = 4000
+
+    /// The release page for a version — same `v`-prefixed tag naming `SelfUpdater` uses to
+    /// build the download URL. Derived rather than carried through `Outcome`, so the weekly
+    /// channel (which only ever persists a version) can offer the link too.
+    static func releasePageURL(forVersion version: String) -> URL? {
+        URL(string: "https://github.com/\(repo)/releases/tag/v\(version)")
+    }
+
+    /// Make a remote release body safe to put on screen: drop git trailers, collapse the
+    /// blank-line runs that leaves behind, and cap the length. Nothing here assumes the
+    /// body is short, non-empty, or well-formed — it arrives over the network.
+    static func sanitizeNotes(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        var kept: [String] = []
+        for line in raw.replacingOccurrences(of: "\r\n", with: "\n")
+                       .split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if isTrailer(trimmed) { continue }
+            // Collapse runs of blanks (and drop leading ones) so stripping a trailer
+            // doesn't leave a hole at the end of the notes.
+            if trimmed.isEmpty, kept.last?.isEmpty ?? true { continue }
+            kept.append(trimmed.isEmpty ? "" : String(line))
+        }
+        while kept.last?.isEmpty ?? false { kept.removeLast() }
+        guard !kept.isEmpty else { return nil }
+        let joined = kept.joined(separator: "\n")
+        return joined.count > notesCharacterCap
+            ? String(joined.prefix(notesCharacterCap)) + "…"
+            : joined
+    }
+
+    /// Git trailer lines — `Co-Authored-By:`, `Signed-off-by:`, `Reviewed-by:` — which
+    /// GitHub copies verbatim from the commit into the release body. Commit plumbing, not
+    /// news: users opened the changelog to read what changed.
+    static func isTrailer(_ line: String) -> Bool {
+        guard let colon = line.firstIndex(of: ":") else { return false }
+        let token = line[line.startIndex..<colon]
+        guard !token.isEmpty, token.allSatisfy({ $0.isLetter || $0 == "-" }) else { return false }
+        return token.lowercased().hasSuffix("-by")
     }
 
     /// Network happens ONLY here (and checkStable above). Called from the About tab's
@@ -111,11 +192,65 @@ enum UpdateCheck {
             let latest = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
             let pageURL = (obj["html_url"] as? String).flatMap(URL.init(string:))
                 ?? URL(string: "https://github.com/\(repo)/releases/latest")!
-            return isNewer(latest, than: current) ? .update(latest: latest, url: pageURL)
-                                                  : .upToDate(current)
+            // This channel gets the changelog for free — the release body is already in
+            // the response we just parsed for the tag. No second request.
+            return isNewer(latest, than: current)
+                ? .update(latest: latest, url: pageURL, notes: sanitizeNotes(obj["body"] as? String))
+                : .upToDate(current)
         } catch {
             return .failed(error.localizedDescription)
         }
+    }
+
+    /// One block of a rendered changelog.
+    ///
+    /// GitHub returns Markdown, but SwiftUI's `Text` only interprets INLINE markdown
+    /// (bold / code / links) — headings and bullets pass through as literal `##` and `-`.
+    /// So the block markers are stripped here, and the view renders each `text` as inline
+    /// markdown at the weight its `kind` calls for. Deliberately small: this is a release
+    /// note, not a document, and a real Markdown engine is a dependency we don't need.
+    struct NoteBlock: Identifiable {
+        enum Kind: Equatable { case heading, bullet, paragraph }
+        let id: Int
+        let kind: Kind
+        let text: String
+    }
+
+    /// An ATX heading needs a SPACE after the hashes — Markdown's own rule, and the reason
+    /// a bare `hasPrefix("#")` is wrong: a release note opening with an issue reference
+    /// ("#42 sửa lỗi gõ tắt") would otherwise be promoted to a heading with its `#` eaten,
+    /// rendering as bold "42 sửa lỗi gõ tắt".
+    static func isHeading(_ trimmed: String) -> Bool {
+        guard trimmed.hasPrefix("#") else { return false }
+        let rest = trimmed.drop(while: { $0 == "#" })
+        return rest.isEmpty || rest.hasPrefix(" ")
+    }
+
+    /// Split sanitized notes into renderable blocks. Blank lines are dropped: the view
+    /// spaces blocks itself, so carrying them through would double the gaps.
+    static func noteBlocks(_ notes: String) -> [NoteBlock] {
+        var out: [NoteBlock] = []
+        for line in notes.split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            let kind: NoteBlock.Kind
+            var text = trimmed
+            if isHeading(trimmed) {
+                kind = .heading
+                text = String(trimmed.drop(while: { $0 == "#" })).trimmingCharacters(in: .whitespaces)
+            } else if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ")
+                        || trimmed == "-" || trimmed == "*" {
+                // The bare-marker case matters: a markerless bullet would otherwise fall
+                // through as a paragraph reading "-" instead of being dropped as empty.
+                kind = .bullet
+                text = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces)
+            } else {
+                kind = .paragraph
+            }
+            guard !text.isEmpty else { continue }
+            out.append(NoteBlock(id: out.count, kind: kind, text: text))
+        }
+        return out
     }
 
     /// Numeric, dot-separated compare: "1.1.2" > "1.1.1" > "1.1".
@@ -242,6 +377,7 @@ enum SelfUpdater {
 
                 await MainActor.run {
                     UpdateCheck.pendingUpdateVersion = nil   // installed; nothing left to nag about
+                    UpdateCheck.pendingUpdateNotes = nil
                     let done = NSAlert()
                     done.messageText = String(format: VTLocalized("Updated to %@"), version)
                     done.informativeText = VTLocalized("Update done body")

--- a/AppTests/AppSupportTests.swift
+++ b/AppTests/AppSupportTests.swift
@@ -52,26 +52,108 @@ final class AppSupportTests: XCTestCase {
         XCTAssertFalse(UpdateCheck.currentVersion().isEmpty)
     }
 
+    func testReleaseNotesSanitizing() {
+        XCTAssertNil(UpdateCheck.sanitizeNotes(nil))
+        XCTAssertNil(UpdateCheck.sanitizeNotes(""))
+        XCTAssertNil(UpdateCheck.sanitizeNotes("\n\n  \n"))          // blank-only → nothing to show
+
+        // Git trailers are commit plumbing; the release body carries them verbatim, and
+        // stripping one must not leave a hole at the end (v1.6.3 shipped with exactly this).
+        let body = "## Tính năng mới\n\n- Phím ngoặc `[` ra ơ\n\nCảm ơn bạn Tuấn Linh\n\n" +
+                   "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n"
+        let clean = UpdateCheck.sanitizeNotes(body)
+        XCTAssertNotNil(clean)
+        XCTAssertFalse(clean!.contains("Co-Authored-By"))
+        XCTAssertFalse(clean!.hasSuffix("\n"))
+        XCTAssertTrue(clean!.contains("Cảm ơn bạn Tuấn Linh"))
+        XCTAssertFalse(clean!.contains("\n\n\n"))                    // blank runs collapsed
+        XCTAssertTrue(UpdateCheck.isTrailer("Signed-off-by: A B"))
+        XCTAssertTrue(UpdateCheck.isTrailer("Reviewed-By: A B"))
+        XCTAssertFalse(UpdateCheck.isTrailer("Ví dụ: th[ → thơ"))    // a colon alone isn't a trailer
+        XCTAssertFalse(UpdateCheck.isTrailer("- Bật ở Cài đặt: Thử nghiệm"))
+
+        // Long bodies are truncated, not rendered whole into a 640pt window.
+        let huge = UpdateCheck.sanitizeNotes(String(repeating: "x", count: 9000))
+        XCTAssertEqual(huge?.count, UpdateCheck.notesCharacterCap + 1)   // + the ellipsis
+    }
+
+    func testReleaseNoteBlockParsing() {
+        let blocks = UpdateCheck.noteBlocks("## Tính năng mới\n\n- **Phím ngoặc**\n* second\nplain line")
+        XCTAssertEqual(blocks.count, 4)                      // blank line dropped
+        XCTAssertEqual(blocks[0].kind, .heading)
+        XCTAssertEqual(blocks[0].text, "Tính năng mới")      // marker stripped, not rendered as "##"
+        XCTAssertEqual(blocks[1].kind, .bullet)
+        XCTAssertEqual(blocks[1].text, "**Phím ngoặc**")     // inline markdown left for Text
+        XCTAssertEqual(blocks[2].kind, .bullet)              // "*" bullets too
+        XCTAssertEqual(blocks[3].kind, .paragraph)
+        XCTAssertEqual(UpdateCheck.noteBlocks("").count, 0)
+        XCTAssertEqual(UpdateCheck.noteBlocks("###\n-  ").count, 0)   // markers with no text
+
+        // ATX headings need a space after the hashes. An issue reference opening a line is
+        // NOT a heading — treating it as one ate the "#" and bolded the rest.
+        let issueRef = UpdateCheck.noteBlocks("#42 sửa lỗi gõ tắt")
+        XCTAssertEqual(issueRef.first?.kind, .paragraph)
+        XCTAssertEqual(issueRef.first?.text, "#42 sửa lỗi gõ tắt")
+        XCTAssertTrue(UpdateCheck.isHeading("## Heading"))
+        XCTAssertFalse(UpdateCheck.isHeading("#42"))
+
+        XCTAssertEqual(UpdateCheck.releasePageURL(forVersion: "1.6.3")?.absoluteString,
+                       "https://github.com/\(UpdateCheck.repo)/releases/tag/v1.6.3")
+    }
+
     // MARK: Updater — network paths via a URLProtocol stub
 
     func testCheckPathsAgainstStubbedNetwork() async {
         URLProtocol.registerClass(StubURLProtocol.self)
         defer { URLProtocol.unregisterClass(StubURLProtocol.self) }
 
-        // Stable manifest newer than current → .update with the manifest URL.
+        // Stable manifest newer than current → .update with the manifest URL. The stable
+        // channel has no changelog of its own, so it must go on to ask for the TAG's
+        // release body (`releases/tags/v99.0.0`) — that's what gives both channels notes.
         StubURLProtocol.responder = { url in
             if url.absoluteString.contains("stable.json") {
                 return (200, #"{"version":"99.0.0","url":"https://example.com/rel"}"#)
             }
-            return (200, #"{"tag_name":"v99.0.0","html_url":"https://example.com/gh"}"#)
+            if url.absoluteString.contains("releases/tags/v99.0.0") {
+                // ##"…"## delimiters, and the body starts with \n: a literal `"##` inside a
+                // #"…"# raw string would close it early. The leading blank line also proves
+                // sanitizeNotes trims it off the front.
+                return (200, ##"{"tag_name":"v99.0.0","body":"\n## Heading\n- from the tag"}"##)
+            }
+            return (200, #"{"tag_name":"v99.0.0","html_url":"https://example.com/gh","body":"- from latest"}"#)
         }
-        if case let .update(latest, url) = await UpdateCheck.checkStable() {
+        if case let .update(latest, url, notes) = await UpdateCheck.checkStable() {
             XCTAssertEqual(latest, "99.0.0")
             XCTAssertEqual(url.absoluteString, "https://example.com/rel")
+            XCTAssertEqual(notes, "## Heading\n- from the tag")
         } else { XCTFail("expected .update from stable") }
-        if case let .update(latest, _) = await UpdateCheck.check() {
+        if case let .update(latest, _, notes) = await UpdateCheck.check() {
             XCTAssertEqual(latest, "99.0.0")
+            XCTAssertEqual(notes, "- from latest")   // free: same response as the tag lookup
         } else { XCTFail("expected .update from latest") }
+
+        // A release with no body is still an update — just without the notes box.
+        StubURLProtocol.responder = { url in
+            url.absoluteString.contains("stable.json")
+                ? (200, #"{"version":"99.0.0","url":"https://example.com/rel"}"#)
+                : (200, #"{"tag_name":"v99.0.0"}"#)
+        }
+        if case let .update(_, _, notes) = await UpdateCheck.checkStable() {
+            XCTAssertNil(notes)
+        } else { XCTFail("bodyless release must still be .update") }
+
+        // The load-bearing invariant of the whole feature: the CHANGELOG lookup is
+        // best-effort, so a tag endpoint that 404s (tag named differently, release deleted,
+        // rate limit) must still yield .update — the version is the news, notes are extra.
+        StubURLProtocol.responder = { url in
+            url.absoluteString.contains("stable.json")
+                ? (200, #"{"version":"99.0.0","url":"https://example.com/rel"}"#)
+                : (404, #"{"message":"Not Found"}"#)
+        }
+        if case let .update(latest, _, notes) = await UpdateCheck.checkStable() {
+            XCTAssertEqual(latest, "99.0.0")
+            XCTAssertNil(notes)
+        } else { XCTFail("a failed notes fetch must not fail the update check") }
 
         // Same version → upToDate.
         let cur = UpdateCheck.currentVersion()


### PR DESCRIPTION
Thêm changelog để người dùng biết có gì mới khi cập nhật phiên bản.

<img width="1392" height="1406" alt="CleanShot 2026-08-15 at 1  36 09@2x" src="https://github.com/user-attachments/assets/d071e537-d7cd-4dda-820f-ce4be75454a3" />
