### PR TITLE
fix(menu): bỏ mục Cài đặt hệ thống trong menu IME

### DIFF
--- a/App/Sources/TelexInputController.swift
+++ b/App/Sources/TelexInputController.swift
@@ -1832,21 +1832,10 @@ final class TelexInputController: IMKInputController {
         settings.target = self
         menu.addItem(settings)
 
-        // System Settings → Keyboard (Text Input / Input Sources) — where users
-        // add/remove the input source and reach the Edit… sheet.
-        let sysSettings = NSMenuItem(title: VTLocalized("System Settings…"),
-                                     action: #selector(openSystemKeyboardSettings(_:)), keyEquivalent: "")
-        sysSettings.target = self
-        menu.addItem(sysSettings)
-
         return menu
     }
 
-    @objc private func openSystemKeyboardSettings(_ sender: Any?) {
-        Self.openKeyboardInputSources()
-    }
-
-    /// Shared by the IME menu and the Settings window: open System Settings →
+    /// Shared by the Settings window: open System Settings →
     /// Keyboard and (with Accessibility) press through to All Input Sources.
     static func openKeyboardInputSources() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.Keyboard-Settings.extension") {


### PR DESCRIPTION
## Thay đổi gì

Menu IME kết thúc ở **Cài đặt…**. Bỏ dòng **Cài đặt hệ thống…** (mở Keyboard → Input Sources). Nút tương ứng trong cửa sổ Cài đặt ViệtTelex vẫn giữ.

## Loại thay đổi

- [ ] Rule cơ chế gõ (`typing-modes.yml`)
- [ ] Engine / validator (`TelexCore/`)
- [x] App: routing per-app, IMKit, CGEventTap, Settings UI (`App/Sources/`)
- [ ] Tài liệu (`docs/`, `README.md`, `BAO-LOI.md`)
- [ ] Khác:

## Đã test

- [ ] `cd TelexCore && swift test` xanh
- [ ] Có golden test cho hành vi mới trong `EngineTests.swift` (bắt buộc khi sửa engine)
- [ ] `swift test -c release --filter 'Benchmark|ZeroAllocation'` xanh — hot path không cấp phát heap
- [ ] Đã cài lên máy thật (`Scripts/dev-install.sh`) và gõ thử trong app bị ảnh hưởng, theo [`docs/checklist.md`](https://github.com/ptrinh/viettelex/blob/main/docs/checklist.md)

Máy đã test:

## Ghi chú cho reviewer

`openKeyboardInputSources()` vẫn dùng từ cửa sổ Cài đặt. Chỉ gỡ menu item và selector `openSystemKeyboardSettings`.


Made with [Cursor](https://cursor.com)