### PR TITLE
fix(engine): r sau sec không bị nuốt khi gõ secret

### DIFF
--- a/TelexCore/Sources/TelexCore/TelexEngine.swift
+++ b/TelexCore/Sources/TelexCore/TelexEngine.swift
@@ -1533,6 +1533,15 @@ public struct TelexEngine {
                         rawLetter[toneKeys[j]] = pCount - 1
                     }
                     pToneKeyCount = 0
+                } else if stopCodaRejectsTone(t) {
+                    // OpenKey (`if !isChanged insertKey`): huyền/hỏi/ngã on a
+                    // stop coda are a no-op — render() would drop them and the
+                    // key vanished ("sec"+"r" stayed "sec", so "secret" needed
+                    // a doubled r). Type the letter instead. Tone-THEN-coda
+                    // ("baft"→bat) still drops at render: the tone was legal
+                    // when typed.
+                    appendLetter(base: lower, mark: .none, upper: upper)
+                    rawLetter[at] = pCount - 1
                 } else {
                     pTone = t
                     // English/code signal ONLY when a lowercase letter came BEFORE
@@ -1812,6 +1821,9 @@ public struct TelexEngine {
                         rawLetter[toneKeys[j]] = pCount - 1
                     }
                     pToneKeyCount = 0
+                } else if stopCodaRejectsTone(t) {
+                    appendLetter(base: key, mark: .none, upper: false)
+                    rawLetter[at] = pCount - 1
                 } else {
                     pTone = t
                     rawLetter[at] = -1
@@ -2088,6 +2100,39 @@ public struct TelexEngine {
             return true
         }
         return false
+    }
+
+    /// Parse-time twin of `hasStopCoda` — `renderLetters` is stale inside parseStep.
+    @inline(__always)
+    private func lettersHaveStopCoda(_ count: Int) -> Bool {
+        guard count > 0 else { return false }
+        let last = letters[count - 1].base
+        if last == UInt8(ascii: "p") || last == UInt8(ascii: "t")
+            || last == UInt8(ascii: "c") || last == UInt8(ascii: "k") {
+            return true
+        }
+        if last == UInt8(ascii: "h"), count >= 2, letters[count - 2].base == UInt8(ascii: "c") {
+            return true
+        }
+        return false
+    }
+
+    /// Parse-time twin of `isUkRime`.
+    @inline(__always)
+    private func lettersAreUkRime(_ count: Int) -> Bool {
+        count >= 2 && letters[count - 1].base == UInt8(ascii: "k")
+            && letters[count - 2].base == UInt8(ascii: "u")
+            && letters[count - 2].mark == .horn
+    }
+
+    /// True when applying `tone` now would be silently dropped by render()
+    /// (huyền/hỏi/ngã on a stop coda, except ừk). The key should be a letter.
+    @inline(__always)
+    private func stopCodaRejectsTone(_ tone: Tone) -> Bool {
+        guard tone == .grave || tone == .hook || tone == .tilde else { return false }
+        guard lettersHaveStopCoda(pCount) else { return false }
+        if tone == .grave && lettersAreUkRime(pCount) { return false }
+        return true
     }
 
     @inline(__always)

--- a/TelexCore/Tests/TelexCoreTests/EngineTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/EngineTests.swift
@@ -678,8 +678,10 @@ final class EngineGoldenTests: XCTestCase {
     }
 
     // B2: stop codas -p, -t, -c, -ch only allow sắc (´) and nặng (.). An invalid
-    // huyền/hỏi/ngã is dropped (the syllable keeps no tone) rather than composing
-    // an illegal word like "bàt".
+    // huyền/hỏi/ngã typed AFTER the coda is a literal letter (OpenKey: if the
+    // tone cannot land, insert the key) rather than composing "bàt" OR swallowing
+    // the key ("sec"+"r" used to stay "sec"). Tone typed BEFORE the coda still
+    // drops at render — it was legal when entered.
     func testStopCodaToneConstraint() {
         // Allowed: sắc / nặng.
         XCTAssertEqual(compose("bats"), "bát")
@@ -688,13 +690,18 @@ final class EngineGoldenTests: XCTestCase {
         XCTAssertEqual(compose("hocj"), "học")
         XCTAssertEqual(compose("caps"), "cáp")
 
-        // Rejected on stop coda -> tone dropped.
-        XCTAssertEqual(compose("batf"), "bat")   // no huyền on -t
-        XCTAssertEqual(compose("batr"), "bat")   // no hỏi on -t
-        XCTAssertEqual(compose("batx"), "bat")   // no ngã on -t
-        XCTAssertEqual(compose("sachf"), "sach") // no huyền on -ch
-        XCTAssertEqual(compose("capr"), "cap")   // no hỏi on -p
-        XCTAssertEqual(compose("hocf"), "hoc")   // no huyền on -c
+        // Rejected on stop coda -> key is a letter, not a vanished tone.
+        XCTAssertEqual(compose("batf"), "batf")   // no huyền on -t
+        XCTAssertEqual(compose("batr"), "batr")   // no hỏi on -t
+        XCTAssertEqual(compose("batx"), "batx")   // no ngã on -t
+        XCTAssertEqual(compose("sachf"), "sachf") // no huyền on -ch
+        XCTAssertEqual(compose("capr"), "capr")   // no hỏi on -p
+        XCTAssertEqual(compose("hocf"), "hocf")   // no huyền on -c
+
+        // Tone first, then stop coda: still dropped at render (illegal "bàt").
+        XCTAssertEqual(compose("baft"), "bat")
+        XCTAssertEqual(compose("bart"), "bat")
+        XCTAssertEqual(compose("baxt"), "bat")
 
         // Non-stop codas (-n, -ng, -nh, -m) still allow every tone.
         XCTAssertEqual(compose("banf"), "bàn")
@@ -703,17 +710,32 @@ final class EngineGoldenTests: XCTestCase {
         XCTAssertEqual(compose("lamf"), "làm")
     }
 
+    // User report: typing "secret" in Vietnamese Telex required "secrret" because
+    // the first r after "sec" was consumed as hỏi and then dropped on stop coda -c.
+    func testSecretDoesNotSwallowRAfterStopCoda() {
+        XCTAssertEqual(compose("secr"), "secr")
+        XCTAssertEqual(compose("secret"), "secret")
+        XCTAssertEqual(composeSpell("secret"), "secret")
+        XCTAssertEqual(commit("secret"), "secret")
+        XCTAssertEqual(commit("secrets"), "secrets")
+        // ưk exception: huyền still lands; hỏi/ngã still cannot (literal).
+        XCTAssertEqual(compose("uwkf"), "ừk")
+        XCTAssertEqual(compose("uwkr"), "ưkr")
+        XCTAssertEqual(compose("uwkx"), "ưkx")
+    }
+
     // Regression: the render-time tone drop must cover EXACTLY the stop codas the
     // validator's toneMask calls stop — including -k (ak/ăk/ưk: Đắk, Lắk). "bakf"
     // used to render "bàk" (an illegal syllable that only the boundary auto-restore
-    // cleaned up) while "batf" silently dropped the huyền. Parity across all five.
+    // cleaned up). Invalid tones AFTER the coda are now letters; tone-THEN-coda
+    // still drops at render. Parity across all five.
     func testStopCodaToneDropParityAcrossAllCodas() {
-        // Invalid tones (huyền/hỏi/ngã) are dropped, not composed, on every stop coda.
+        // Invalid tones after a stop coda type through as letters.
         for (coda, keys) in [("t", "bat"), ("c", "bac"), ("p", "bap"),
                              ("ch", "bach"), ("k", "bak")] {
             for tone in ["f", "r", "x"] {
-                XCTAssertEqual(compose(keys + tone), keys,
-                               "tone \(tone) must be dropped on stop coda -\(coda)")
+                XCTAssertEqual(compose(keys + tone), keys + tone,
+                               "tone \(tone) must type through on stop coda -\(coda)")
             }
         }
         // …and the legal sắc/nặng on a -k rime still compose (Đắk Lắk, "ưk").
@@ -725,11 +747,10 @@ final class EngineGoldenTests: XCTestCase {
         // Bare "k" is a stop coda; "kh"/"ng" are not — a following tone key still lands.
         XCTAssertEqual(compose("khof"), "khò")
         XCTAssertEqual(compose("bangf"), "bàng")
-        // A -k word that is not Vietnamese still reverts to the raw keys at the
-        // boundary; dropping the tone must not make the word look valid.
+        // A -k word that is not Vietnamese stays the raw keys (f is now a letter).
         var e = TelexEngine(); e.liveSpellCheck = true
         for ch in "bakf" { _ = e.feed(ch) }
-        XCTAssertEqual(e.composed, "bak")
+        XCTAssertEqual(e.composed, "bakf")
         XCTAssertEqual(e.commitText(autoRestore: true), "bakf")
     }
 

--- a/TelexCore/Tests/TelexCoreTests/VNITests.swift
+++ b/TelexCore/Tests/TelexCoreTests/VNITests.swift
@@ -152,6 +152,17 @@ final class VNITests: XCTestCase {
         XCTAssertEqual(vniCommit("hello"), "hello")
     }
 
+    // Invalid VNI tone digits after a stop coda type through (same OpenKey rule
+    // as Telex s/f/r/x/j): "sec3" must stay "sec3", not swallow 3 as hỏi.
+    func testStopCodaRejectsToneDigitAsLiteral() {
+        XCTAssertEqual(vni("sec3"), "sec3")
+        XCTAssertEqual(vni("bat2"), "bat2")
+        XCTAssertEqual(vni("bat3"), "bat3")
+        XCTAssertEqual(vni("bat4"), "bat4")
+        XCTAssertEqual(vni("bat1"), "bát")   // sắc still lands
+        XCTAssertEqual(vni("bat5"), "bạt")   // nặng still lands
+    }
+
     // MARK: Boundary restore reverts invalid VNI tokens
 
     func testInvalidTokenRestoresRaw() {


### PR DESCRIPTION
## Thay đổi gì

Gõ `secret` khi bộ gõ tiếng Việt đang bật phải gõ thành `secrret`: sau `sec`, phím `r` bị ăn như dấu hỏi rồi bị **bỏ im** vì vần `-c` không nhận hỏi/huyền/ngã — màn hình vẫn `sec`, phải thêm `r` nữa mới thành `secr`.

**Trước:** `sec` + `r` → `sec` (phím biến mất).
**Sau:** `sec` + `r` → `secr`; gõ `secret` ra `secret` ngay khi đang gõ, không cần nhân đôi `r`.

Cùng luật OpenKey (`if !isChanged insertKey`): nếu dấu không thể gắn lên vần tắt thì phím thành chữ thường. Dấu gõ **trước** coda (`baft` → `bat`) vẫn bị drop lúc render — lúc gõ dấu còn hợp lệ.

## Loại thay đổi

- [x] Engine / validator (`TelexCore/`)

## Đã test

- [x] `cd TelexCore && swift test` xanh (261 tests, 0 failures)
- [x] Có golden test cho hành vi mới trong `EngineTests.swift` (`testSecretDoesNotSwallowRAfterStopCoda`)
- [x] `swift test -c release --filter 'Benchmark|ZeroAllocation'` xanh — 7/7, hot path không cấp phát heap
- [ ] Đã cài lên máy thật (`Scripts/dev-install.sh`) và gõ thử

Máy đã test: unit test trên macOS (Xcode toolchain), chưa cài IME lên máy thật.

## Ghi chú cho reviewer

- Parse-time: `stopCodaRejectsTone` trên buffer `letters` (Telex `s/f/r/x/j` và VNI `2/3/4`). `renderLetters` lúc parse còn stale.
- Sắc/nặng sau vần tắt không đổi (`bats`→`bát`, `hocj`→`học`). Ngoại lệ teencode `ừk` giữ huyền.
- `secret`/`secrets` commit đúng raw; suite `restore_raw` floor không tụt (7135/7216).
- Đánh đổi: typo `batf` (định `bats`) trước đây bị nuốt im thành `bat`; giờ hiện `batf` — thấy sai, backspace được. Khớp Unikey/OpenKey hơn là nuốt phím.