### PR TITLE
fix(secure-input): nhận diện 1Password giữ khoá sau sleep

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -69,6 +69,11 @@ Press “Repair automatically”: VietTelex removes its own stuck entry and asks
 "Vietnamese typing is blocked (Secure Input)" = "Vietnamese typing is blocked (Secure Input)";
 "If this is Terminal/iTerm2: turn off “Secure Keyboard Entry”" = "If this is Terminal/iTerm2: turn off “Secure Keyboard Entry”";
 "Status: Blocked by Secure Input" = "Status: Blocked by Secure Input";
+"%@ left Secure Input on — click its window then click away, or quit it" = "%@ left Secure Input on — click its window then click away, or quit it";
+"loginwindow is listed, but %@ often holds Secure Input after sleep — click it then click away, or quit it" = "loginwindow is listed, but %@ often holds Secure Input after sleep — click it then click away, or quit it";
+"loginwindow is holding Secure Input after sleep — lock the screen (⌃⌘Q) and unlock" = "loginwindow is holding Secure Input after sleep — lock the screen (⌃⌘Q) and unlock";
+"An app is holding Secure Input (a password field) — click away from that field, or quit the app named above" = "An app is holding Secure Input (a password field) — click away from that field, or quit the app named above";
+"Switch to %@ (then click away)" = "Switch to %@ (then click away)";
 
 /* Sticky input source (field report 15/08/2026 — Word comment boxes reset the input source) */
 "Keep VietTelex when macOS auto-switches the input source (experimental)" = "Keep VietTelex when macOS auto-switches the input source (experimental)";

--- a/App/Resources/vi.lproj/Localizable.strings
+++ b/App/Resources/vi.lproj/Localizable.strings
@@ -228,6 +228,11 @@ Bấm “Sửa tự động”: VietTelex tự xoá mục bị kẹt của chín
 "Vietnamese typing is blocked (Secure Input)" = "Gõ tiếng Việt đang bị chặn (Secure Input)";
 "If this is Terminal/iTerm2: turn off “Secure Keyboard Entry”" = "Nếu là Terminal/iTerm2: tắt “Secure Keyboard Entry” trong menu app đó";
 "Status: Blocked by Secure Input" = "Trạng thái: Bị chặn bởi Secure Input";
+"%@ left Secure Input on — click its window then click away, or quit it" = "%@ giữ Secure Input — bấm vào cửa sổ đó rồi bấm ra, hoặc thoát app";
+"loginwindow is listed, but %@ often holds Secure Input after sleep — click it then click away, or quit it" = "Hệ thống ghi loginwindow nhưng %@ hay giữ khoá sau khi ngủ — bấm vào nó rồi bấm ra, hoặc thoát";
+"loginwindow is holding Secure Input after sleep — lock the screen (⌃⌘Q) and unlock" = "loginwindow giữ Secure Input sau khi ngủ — khoá màn hình (⌃⌘Q) rồi mở lại";
+"An app is holding Secure Input (a password field) — click away from that field, or quit the app named above" = "Một app đang giữ Secure Input (ô mật khẩu) — bấm ra khỏi ô đó, hoặc thoát app ghi ở trên";
+"Switch to %@ (then click away)" = "Bấm sang %@ (rồi bấm ra)";
 
 /* Sticky input source (field report 15/08/2026 — ô comment Word reset bộ gõ) */
 "Keep VietTelex when macOS auto-switches the input source (experimental)" = "Giữ VietTelex khi macOS tự đổi bộ gõ (thử nghiệm)";

--- a/App/Sources/SecureInputMonitor.swift
+++ b/App/Sources/SecureInputMonitor.swift
@@ -4,23 +4,27 @@
 // được auto-chọn; user nghi "do đang SSH").
 //
 // Nguyên nhân thật: một process đang giữ SECURE EVENT INPUT (Terminal/iTerm2 bật
-// "Secure Keyboard Entry", ô password treo quyền, loginwindow…). Khi secure input
-// active, macOS vô hiệu MỌI IME bên thứ ba — dòng "ViệtTelex" mờ trong picker là
-// TextInputMenuAgent vẽ từ metadata tĩnh của bundle, mình không sửa động được, và
-// IMK menu của mình cũng không mở được vì không chọn được input source.
+// "Secure Keyboard Entry", ô password treo quyền, loginwindow, 1Password sau
+// sleep…). Khi secure input active, macOS vô hiệu MỌI IME bên thứ ba — dòng
+// "ViệtTelex" mờ trong picker là TextInputMenuAgent vẽ từ metadata tĩnh của
+// bundle, mình không sửa động được, và IMK menu của mình cũng không mở được vì
+// không chọn được input source.
 //
-// Không chặn được (policy của OS), nhưng biến "không rõ nguyên nhân" thành "có tên
-// thủ phạm" thì được, vì PROCESS NÀY VẪN SỐNG khi bị mờ (IMKServer không bị kill):
+// Không chặn được (policy của OS — không có API nhả hộ, kẻo malware cũng làm
+// được), nhưng biến "không rõ nguyên nhân" thành "có tên thủ phạm" thì được, vì
+// PROCESS NÀY VẪN SỐNG khi bị mờ (IMKServer không bị kill):
 //  1. Icon menu bar TẠM THỜI chỉ hiện khi đang bị chặn, ghi rõ thủ phạm + PID,
-//     tự biến mất khi hết chặn.
+//     tự biến mất khi hết chặn. Gợi ý theo ĐÚNG bệnh (1Password sau sleep ≠
+//     Terminal Secure Keyboard Entry ≠ khoá mồ côi).
 //  2. Transition ON/OFF ghi unified log (LUÔN — kể cả khi debugLogging off; sự kiện
 //     hiếm, không có text người dùng) + DebugLog ring.
 //  3. Dòng "Secure input:" trong debug snapshot (click Status: OK) và IMK menu.
 //
 // Phát hiện: notification input-source-changed là đường nhanh (secure input bật
-// thường kèm macOS đá selection sang ABC), poll 5s là lưới an toàn — vi phạm có chủ
-// đích ethos "no timers" của main.swift (tiền lệ: trustPoll) vì lúc bị chặn thì
-// chính là lúc KHÔNG có event nào tới được mình.
+// thường kèm macOS đá selection sang ABC); didWake / screenIsUnlocked bắt ca
+// 1Password-sau-sleep ngay khi mở máy (ioreg hay báo NHẦM loginwindow); poll 5s
+// là lưới an toàn — vi phạm có chủ đích ethos "no timers" của main.swift (tiền
+// lệ: trustPoll) vì lúc bị chặn thì chính là lúc KHÔNG có event nào tới được mình.
 
 import AppKit
 import Carbon.HIToolbox
@@ -46,6 +50,19 @@ final class SecureInputMonitor {
         }
     }
 
+    /// Gợi ý theo bệnh, tách thuần để test được. ioreg SAU SLEEP hay ghi
+    /// loginwindow trong khi 1Password mới là process EnableSecureEventInput
+    /// (1Password Community #25015, 07/2026: password field vẫn highlighted dù
+    /// app khác đang focus; quit 1Password hoặc click vào rồi click ra mới nhả).
+    enum HintKind: Equatable {
+        case orphan
+        case passwordManager(String)
+        case loginwindowWithPasswordManager(String)
+        case loginwindowStuck
+        case terminal
+        case generic
+    }
+
     /// Process còn sống không — kill(pid, 0) không gửi signal, chỉ hỏi tồn tại;
     /// EPERM nghĩa là "sống nhưng không phải của mình" nên vẫn tính là sống.
     static func processIsAlive(_ pid: pid_t) -> Bool {
@@ -57,7 +74,9 @@ final class SecureInputMonitor {
     /// IOKit không nêu tên — hiếm, nhưng "active mà không rõ ai" vẫn đáng báo).
     private(set) var activeHolder: Holder?
     private var timer: Timer?
+    private var settleWork: DispatchWorkItem?
     private var statusItem: NSStatusItem?
+    private var workspaceObservers: [NSObjectProtocol] = []
 
     /// VietTelex có đang là selection của user không — chốt lần cuối TRƯỚC khi bị
     /// chặn. Cập nhật ở mỗi lần check lúc secure input off; đóng băng suốt lúc bị
@@ -73,6 +92,40 @@ final class SecureInputMonitor {
         t.tolerance = 2.0   // coalesce với wakeup khác — đây là lưới an toàn, không cần đúng nhịp
         RunLoop.main.add(t, forMode: .common)
         timer = t
+
+        // 1Password (và loginwindow) bật SI lúc lock/sleep; IME bị mờ TRƯỚC khi
+        // input-source-changed hay poll 5s kịp chạy. Check ngay + một nhịp settle
+        // vì UI khoá của 1Password hiện SAU khi loginwindow nhả.
+        // NSWorkspace không có screensDidUnlockNotification (SDK 13); unlock đi
+        // qua DistributedNotificationCenter `com.apple.screenIsUnlocked`.
+        let nc = NSWorkspace.shared.notificationCenter
+        workspaceObservers.append(nc.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.checkSoon(reason: "wake")
+        })
+        workspaceObservers.append(nc.addObserver(
+            forName: NSWorkspace.screensDidWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.checkSoon(reason: "screens-wake")
+        })
+        workspaceObservers.append(DistributedNotificationCenter.default().addObserver(
+            forName: NSNotification.Name("com.apple.screenIsUnlocked"),
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.checkSoon(reason: "unlock")
+        })
+    }
+
+    /// Check ngay, rồi một lần nữa sau 1.2s. Coalesce wake+unlock thành một settle.
+    func checkSoon(reason: String) {
+        check(reason: reason)
+        settleWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.check(reason: reason + "-settle")
+        }
+        settleWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2, execute: work)
     }
 
     /// Re-check ngay khi có tín hiệu rẻ (đổi input source, mở snapshot). Idempotent,
@@ -89,15 +142,25 @@ final class SecureInputMonitor {
             selectedBeforeBlock = TelexInputController.isVietTelexSelected()
             return
         }
-        guard holder != activeHolder else { return }
+        guard holder != activeHolder else {
+            // PID không đổi, nhưng HINT có thể đổi: sau sleep ioreg vẫn ghi
+            // loginwindow trong khi 1Password đã kịp hiện ô mật khẩu.
+            if holder != nil { updateStatusItem() }
+            return
+        }
         let was = activeHolder
         activeHolder = holder
         if let h = holder {
             // Thẳng vào unified log không qua guard debugLogging của DebugLog.log —
             // sự kiện này cần dấu vết CẢ KHI user chưa kịp bật debug (chính là ca
             // "thỉnh thoảng, không tái hiện được").
+            let kind = currentHintKind(holder: h)
             Signposts.log.notice("secure-input ON — held by \(h.label, privacy: .public) [\(reason, privacy: .public)]")
             DebugLog.log("secure-input ON — held by \(h.label) [\(reason)]")
+            if case .loginwindowWithPasswordManager(let pm) = kind {
+                Signposts.log.notice("secure-input ON — ioreg names loginwindow, \(pm, privacy: .public) is running (common false attribution after sleep)")
+                DebugLog.log("secure-input ON — ioreg names loginwindow, \(pm) is running (common false attribution after sleep)")
+            }
         } else if let w = was {
             Signposts.log.notice("secure-input OFF — was \(w.label) [\(reason, privacy: .public)]")
             DebugLog.log("secure-input OFF — was \(w.label) [\(reason)]")
@@ -116,7 +179,75 @@ final class SecureInputMonitor {
 
     /// Dòng trạng thái cho snapshot + IMK menu. English cho snapshot-side.
     var snapshotLine: String {
-        activeHolder.map { "Secure input: ACTIVE — held by \($0.label)" } ?? "Secure input: off"
+        guard let holder = activeHolder else { return "Secure input: off" }
+        switch currentHintKind(holder: holder) {
+        case .loginwindowWithPasswordManager(let pm):
+            return "Secure input: ACTIVE — held by \(holder.label) (likely \(pm) after sleep)"
+        case .passwordManager:
+            return "Secure input: ACTIVE — held by \(holder.label) (password manager)"
+        default:
+            return "Secure input: ACTIVE — held by \(holder.label)"
+        }
+    }
+
+    // MARK: - Phân loại gợi ý
+
+    static func looksLikePasswordManager(_ name: String?) -> Bool {
+        guard let raw = name?.lowercased(), !raw.isEmpty else { return false }
+        let needles = ["1password", "agilebits", "bitwarden", "lastpass", "keepass"]
+        return needles.contains { raw.contains($0) }
+    }
+
+    static func looksLikeLoginwindow(_ name: String?) -> Bool {
+        guard let raw = name?.lowercased() else { return false }
+        return raw.contains("loginwindow") || raw == "login window"
+    }
+
+    static func looksLikeTerminal(_ name: String?) -> Bool {
+        guard let raw = name?.lowercased() else { return false }
+        return raw.contains("terminal") || raw.contains("iterm")
+            || raw.contains("alacritty") || raw.contains("wezterm")
+            || raw.contains("ghostty") || raw == "kitty"
+    }
+
+    static func canonicalPasswordManagerName(_ name: String) -> String {
+        let n = name.lowercased()
+        if n.contains("1password") || n.contains("agilebits") { return "1Password" }
+        if n.contains("bitwarden") { return "Bitwarden" }
+        if n.contains("lastpass") { return "LastPass" }
+        if n.contains("keepass") { return "KeePassXC" }
+        return name
+    }
+
+    static func classifyHint(holderName: String?, holderAlive: Bool,
+                             runningPasswordManagers: [String]) -> HintKind {
+        if !holderAlive { return .orphan }
+        if looksLikePasswordManager(holderName) {
+            return .passwordManager(canonicalPasswordManagerName(holderName ?? "1Password"))
+        }
+        if looksLikeLoginwindow(holderName), let pm = runningPasswordManagers.first {
+            return .loginwindowWithPasswordManager(pm)
+        }
+        if looksLikeLoginwindow(holderName) { return .loginwindowStuck }
+        if looksLikeTerminal(holderName) { return .terminal }
+        return .generic
+    }
+
+    static func runningPasswordManagerNames() -> [String] {
+        var seen = Set<String>()
+        var out: [String] = []
+        for app in NSWorkspace.shared.runningApplications {
+            let blob = ((app.bundleIdentifier ?? "") + " " + (app.localizedName ?? "")).lowercased()
+            guard looksLikePasswordManager(blob) else { continue }
+            let display = canonicalPasswordManagerName(app.localizedName ?? app.bundleIdentifier ?? "1Password")
+            if seen.insert(display).inserted { out.append(display) }
+        }
+        return out
+    }
+
+    private func currentHintKind(holder: Holder) -> HintKind {
+        Self.classifyHint(holderName: holder.name, holderAlive: holder.alive,
+                          runningPasswordManagers: Self.runningPasswordManagerNames())
     }
 
     // MARK: - Icon menu bar tạm thời
@@ -138,18 +269,75 @@ final class SecureInputMonitor {
                               action: nil, keyEquivalent: "")
         info.isEnabled = false
         menu.addItem(info)
-        // Gợi ý theo ĐÚNG bệnh: khoá mồ côi (process chết không nhả — chỉ logout gỡ
-        // được) khác hẳn Secure Keyboard Entry bật quên (tắt trong menu app là xong).
-        // Khoá mồ côi: mẹo khoá-màn-hình FIELD-VERIFIED 18/08/2026 (ca Lark) — lock
-        // làm loginwindow chiếm secure input rồi nhả khi mở, ghi đè record kẹt.
-        // Rẻ hơn logout nhiều nên khuyên trước; logout là đường chắc chắn dự phòng.
-        let hintText = holder.alive
-            ? VTLocalized("If this is Terminal/iTerm2: turn off “Secure Keyboard Entry”")
-            : VTLocalized("That process exited but the lock is stuck — lock the screen (⌃⌘Q) and unlock; if that fails, log out and back in")
-        let hint = NSMenuItem(title: hintText, action: nil, keyEquivalent: "")
+
+        let kind = currentHintKind(holder: holder)
+        let hint = NSMenuItem(title: Self.hintText(kind), action: nil, keyEquivalent: "")
         hint.isEnabled = false
         menu.addItem(hint)
+
+        if let pm = Self.revealTarget(kind) {
+            menu.addItem(.separator())
+            let reveal = NSMenuItem(
+                title: String(format: VTLocalized("Switch to %@ (then click away)"), pm),
+                action: #selector(MenuActions.revealPasswordManager(_:)),
+                keyEquivalent: "")
+            reveal.target = MenuActions.shared
+            menu.addItem(reveal)
+        }
         item.menu = menu
+    }
+
+    static func hintText(_ kind: HintKind) -> String {
+        switch kind {
+        case .orphan:
+            return VTLocalized("That process exited but the lock is stuck — lock the screen (⌃⌘Q) and unlock; if that fails, log out and back in")
+        case .passwordManager(let pm):
+            return String(format: VTLocalized("%@ left Secure Input on — click its window then click away, or quit it"), pm)
+        case .loginwindowWithPasswordManager(let pm):
+            return String(format: VTLocalized("loginwindow is listed, but %@ often holds Secure Input after sleep — click it then click away, or quit it"), pm)
+        case .loginwindowStuck:
+            return VTLocalized("loginwindow is holding Secure Input after sleep — lock the screen (⌃⌘Q) and unlock")
+        case .terminal:
+            return VTLocalized("If this is Terminal/iTerm2: turn off “Secure Keyboard Entry”")
+        case .generic:
+            return VTLocalized("An app is holding Secure Input (a password field) — click away from that field, or quit the app named above")
+        }
+    }
+
+    static func revealTarget(_ kind: HintKind) -> String? {
+        switch kind {
+        case .passwordManager(let pm), .loginwindowWithPasswordManager(let pm):
+            return pm
+        default:
+            return nil
+        }
+    }
+
+    /// Đưa password manager lên trước — workaround field-verified: focus rồi unfocus
+    /// làm nó gọi DisableSecureEventInput. Không nhả hộ được (không có API).
+    static func activatePasswordManager() {
+        let apps = NSWorkspace.shared.runningApplications.filter { app in
+            let blob = ((app.bundleIdentifier ?? "") + " " + (app.localizedName ?? "")).lowercased()
+            return looksLikePasswordManager(blob)
+        }
+        let preferred = apps.first {
+            ($0.bundleIdentifier ?? "").lowercased().contains("1password.1password")
+        } ?? apps.first {
+            let id = ($0.bundleIdentifier ?? "").lowercased()
+            return !id.contains("helper") && !id.contains("safari")
+        } ?? apps.first
+        if #available(macOS 14.0, *) {
+            preferred?.activate()
+        } else {
+            preferred?.activate(options: [.activateIgnoringOtherApps])
+        }
+    }
+
+    private final class MenuActions: NSObject {
+        static let shared = MenuActions()
+        @objc func revealPasswordManager(_ sender: Any) {
+            SecureInputMonitor.activatePasswordManager()
+        }
     }
 
     // MARK: - Tự kết nối lại sau khi hết chặn

--- a/AppTests/AppSupportTests.swift
+++ b/AppTests/AppSupportTests.swift
@@ -127,6 +127,70 @@ final class AppSupportTests: XCTestCase {
         XCTAssertNotNil(SecureInputMonitor.processName(ProcessInfo.processInfo.processIdentifier))
     }
 
+    func testSecureInputHintClassifiesPasswordManagerAfterSleep() {
+        // Field case 09/2026: wake from sleep with 1Password open → Telex dead
+        // until 1Password is quit. ioreg often NAMES loginwindow (false
+        // attribution, 1Password Community #25015) while 1Password is the
+        // EnableSecureEventInput caller. Hint must not say "turn off Terminal
+        // Secure Keyboard Entry".
+        XCTAssertEqual(
+            SecureInputMonitor.classifyHint(holderName: "1Password", holderAlive: true,
+                                            runningPasswordManagers: ["1Password"]),
+            .passwordManager("1Password"))
+        XCTAssertEqual(
+            SecureInputMonitor.classifyHint(holderName: "1Password Browser Helper", holderAlive: true,
+                                            runningPasswordManagers: []),
+            .passwordManager("1Password"))
+        XCTAssertEqual(
+            SecureInputMonitor.classifyHint(holderName: "loginwindow", holderAlive: true,
+                                            runningPasswordManagers: ["1Password"]),
+            .loginwindowWithPasswordManager("1Password"))
+        XCTAssertEqual(
+            SecureInputMonitor.classifyHint(holderName: "loginwindow", holderAlive: true,
+                                            runningPasswordManagers: []),
+            .loginwindowStuck)
+        XCTAssertEqual(
+            SecureInputMonitor.classifyHint(holderName: "iTerm2", holderAlive: true,
+                                            runningPasswordManagers: ["1Password"]),
+            .terminal)
+        XCTAssertEqual(
+            SecureInputMonitor.classifyHint(holderName: "Lark", holderAlive: false,
+                                            runningPasswordManagers: []),
+            .orphan)
+        XCTAssertEqual(
+            SecureInputMonitor.classifyHint(holderName: "Safari", holderAlive: true,
+                                            runningPasswordManagers: []),
+            .generic)
+        XCTAssertEqual(
+            SecureInputMonitor.revealTarget(.loginwindowWithPasswordManager("1Password")),
+            "1Password")
+        XCTAssertNil(SecureInputMonitor.revealTarget(.terminal))
+        let sleepHint = SecureInputMonitor.hintText(.loginwindowWithPasswordManager("1Password"))
+        XCTAssertTrue(sleepHint.contains("1Password"))
+        XCTAssertFalse(sleepHint.localizedCaseInsensitiveContains("Terminal"),
+                       "sleep+1Password must not be diagnosed as Secure Keyboard Entry")
+        let terminalHint = SecureInputMonitor.hintText(.terminal)
+        XCTAssertTrue(terminalHint.contains("Terminal") || terminalHint.contains("iTerm"),
+                      "iTerm/Terminal Secure Keyboard Entry hint must stay")
+    }
+
+    func testSecureInputPasswordManagerNameMatching() {
+        XCTAssertTrue(SecureInputMonitor.looksLikePasswordManager("1Password"))
+        XCTAssertTrue(SecureInputMonitor.looksLikePasswordManager("com.agilebits.onepassword7"))
+        XCTAssertTrue(SecureInputMonitor.looksLikePasswordManager("Bitwarden"))
+        XCTAssertFalse(SecureInputMonitor.looksLikePasswordManager("Safari"))
+        XCTAssertFalse(SecureInputMonitor.looksLikePasswordManager("Password Manager Settings"))
+        XCTAssertFalse(SecureInputMonitor.looksLikePasswordManager(nil))
+        XCTAssertTrue(SecureInputMonitor.looksLikeLoginwindow("loginwindow"))
+        XCTAssertTrue(SecureInputMonitor.looksLikeLoginwindow("Login Window"))
+        XCTAssertFalse(SecureInputMonitor.looksLikeLoginwindow("1Password"))
+        XCTAssertTrue(SecureInputMonitor.looksLikeTerminal("Terminal"))
+        XCTAssertTrue(SecureInputMonitor.looksLikeTerminal("iTerm2"))
+        XCTAssertFalse(SecureInputMonitor.looksLikeTerminal("1Password"))
+        XCTAssertEqual(SecureInputMonitor.canonicalPasswordManagerName("1Password for Safari"),
+                       "1Password")
+    }
+
     func testBoundedDataEnforcesByteCap() async {
         // data: URLs keep the test off the network; the cap must apply while streaming.
         let small = URLRequest(url: URL(string: "data:text/plain,hello")!)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ VietTelex tự tắt trong secure field — đúng hành vi bảo mật, không 
 </details>
 
 <details>
+<summary><strong>Mở máy từ sleep, đang mở 1Password thì không gõ được Telex?</strong></summary>
+
+Không riêng VietTelex: EVKey, OpenKey, GoTiengViet cũng chết. 1Password giữ **Secure Input** của macOS sau khi ngủ (ô khoá vault vẫn “focus” dù bạn đang ở app khác) — macOS lúc đó vô hiệu mọi bộ gõ bên thứ ba.
+
+Gỡ nhanh: bấm vào cửa sổ 1Password rồi bấm ra, hoặc **Quit 1Password**. Icon `Vᵀ⃠` trên menu bar (khi đang bị chặn) sẽ chỉ đúng hướng đó. Bộ gõ có sẵn của Apple (Simple Telex) thường vẫn dùng được vì không bị disable theo lớp IME bên thứ ba.
+
+Chi tiết: [ghi chú kỹ thuật](docs/MACOS_IME_NOTES.md).
+</details>
+
+<details>
 <summary><strong>Gõ comment trên TikTok (Safari) bị mất chữ cuối khi ấn Enter?</strong></summary>
 
 **Bấm một dấu cách trước khi ấn Enter** là đủ chữ. Hoặc dùng Chrome cho TikTok.

--- a/docs/MACOS_IME_NOTES.md
+++ b/docs/MACOS_IME_NOTES.md
@@ -537,6 +537,46 @@ Không chặn trước được: secure input là nguyên thủy bảo mật c�
 cho app thứ ba từ chối/nhả hộ (cố tình — nhả hộ được thì malware cũng làm được).
 Fix gốc thuộc về app giữ khoá (lớp bug Electron: Enable không Disable khi thoát).
 
+## 1Password sau sleep giữ Secure Input — 2026-09-09 (EVKey/OpenKey/VietTelex cùng chết)
+
+Triệu chứng (Facebook, lặp lại trên EVKey #30 / OpenKey #179 / 1Password
+Community #25014–#25015): mở máy từ sleep, **nếu 1Password đang mở** thì không
+gõ được Telex ở mọi app. Quit 1Password → gõ lại được. Đổi sang EVKey/OpenKey
+cũng chết y hệt — không phải bug Telex, không phải conflict keymap.
+
+Chuỗi nhân quả:
+
+1. 1Password bật `EnableSecureEventInput` khi hiện ô mật khẩu (khoá vault lúc
+   sleep: setting "Lock when device locks or sleeps").
+2. Sau wake, ô mật khẩu của 1Password **vẫn highlighted** dù app khác đang
+   focus — 1Password không gọi `DisableSecureEventInput` (TN2150: process tự
+   Enable thì phải tự Disable cả khi mất focus; Cocoa `NSSecureTextField` thì
+   hệ thống lo hộ, custom field thì không).
+3. macOS vô hiệu **mọi IME bên thứ ba** khi SI active; `CGEventTap` cũng không
+   nhận phím. Apple Simple Telex (first-party) thường vẫn chọn được.
+4. `ioreg -l | grep kCGSSessionSecureInputPID` hay **báo nhầm `loginwindow`**
+   — không tin PID đó là thủ phạm thật. Quit 1Password vẫn nhả khoá dù ioreg
+   không ghi tên nó.
+
+Gỡ, rẻ → chắc:
+
+1. Click vào cửa sổ 1Password rồi click ra (focus/unfocus) — Community-verified.
+2. Unlock 1Password, hoặc Quit 1Password.
+3. Khoá màn hình (⌃⌘Q) rồi mở lại — ghi đè record; đôi khi **làm nặng hơn**
+   đúng reproduction của #25015.
+4. Đăng xuất / đăng nhập.
+
+Không có bộ gõ bên thứ ba nào "không xung đột": Input Monitoring **không**
+bypass SI trên Ventura+ (OpenKey #179 xác nhận). VietTelex chỉ làm được: hiện
+icon `Vᵀ⃠` ngay lúc wake, gọi đúng tên 1Password kể cả khi ioreg ghi
+loginwindow, và reselect IME khi SI tắt (quit 1Password). Fix gốc là 1Password
+phải `DisableSecureEventInput` khi mất focus / sau wake — họ claim đã vá ở
+18.12.26 ("keep Secure Input enabled longer than intended") nhưng field 07–09
+2026 vẫn còn.
+
+Giảm tần suất phía user: tắt **Lock when device locks or sleeps** trong
+1Password (đánh đổi bảo mật), hoặc cập nhật 1Password.
+
 ## ⌘R trong Xcode huỷ đăng ký input source — 2026-08-15 (học từ fork xkhanhs/vtx, 906640f)
 
 Triệu chứng: IME **biến mất khỏi menu bar**, không crash, DebugLog trống. App vẫn


### PR DESCRIPTION
## Thay đổi gì

Sau sleep, nếu 1Password đang mở thì mọi IME bên thứ ba (VietTelex/EVKey/OpenKey) bị macOS disable vì Secure Input kẹt — không phải conflict Telex. Monitor cũ còn chỉ sai: mọi process sống đều bị bảo tắt “Secure Keyboard Entry” trong Terminal.

Sau PR: check SI ngay lúc wake / screens-wake / unlock; nếu ioreg ghi `loginwindow` mà 1Password đang chạy thì hint đúng (bấm vào rồi bấm ra / quit) và có mục menu **Bấm sang 1Password**. Khi 1Password nhả khoá, vẫn reselect VietTelex như trước.

Không nhả hộ được khoá — không có API (policy của OS). Fix gốc thuộc 1Password ([Community #25015](https://www.1password.community/1password-at-work-58/secure-input-blocking-other-apps-event-taps-25015)).

Closes #73

## Loại thay đổi

- [ ] Rule cơ chế gõ (`typing-modes.yml`)
- [ ] Engine / validator (`TelexCore/`)
- [x] App: routing per-app, IMKit, CGEventTap, Settings UI (`App/Sources/`)
- [x] Tài liệu (`docs/`, `README.md`, `BAO-LOI.md`)
- [ ] Khác:

## Đã test

- [ ] `cd TelexCore && swift test` xanh — không đụng engine
- [ ] Có golden test cho hành vi mới trong `EngineTests.swift` (bắt buộc khi sửa engine)
- [ ] `swift test -c release --filter 'Benchmark|ZeroAllocation'` xanh — hot path không cấp phát heap
- [x] `xcodebuild -scheme VietTelex -only-testing:VietTelexTests/AppSupportTests test` xanh (`classifyHint` không đổ sleep+1Password thành Terminal Secure Keyboard Entry)
- [ ] Đã cài lên máy thật (`Scripts/dev-install.sh`) và gõ thử trong app bị ảnh hưởng, theo [`docs/checklist.md`](https://github.com/ptrinh/viettelex/blob/main/docs/checklist.md) — máy dev không có 1Password nên chưa sleep/wake được trên hardware

Máy đã test: macOS 15 / Sequoia, `AppSupportTests` (không có 1Password)

## Ghi chú cho reviewer

- Phân loại hint là hàm thuần (`SecureInputMonitor.classifyHint`) — case `loginwindow` + 1Password đang chạy là false attribution đã ghi ở Community #25015.
- Đừng blame 1Password khi ioreg ghi đúng iTerm/Terminal: Secure Keyboard Entry vẫn là bệnh riêng.
- Cần field-verify: sleep với 1Password mở → icon `Vᵀ⃠` hiện, hint không nói Terminal, bấm vào 1Password rồi bấm ra thì IME sống lại.


Made with [Cursor](https://cursor.com)