### PR TITLE
fix(engine): w thứ hai trên vần ưa hoàn tác ư (huawei)

### DIFF
--- a/TelexCore/Sources/TelexCore/TelexEngine.swift
+++ b/TelexCore/Sources/TelexCore/TelexEngine.swift
@@ -1181,6 +1181,16 @@ public struct TelexEngine {
         return false
     }
 
+    /// ua/uu retarget may land on a predecessor `u` that is unmarked (first w → ư)
+    /// or already horned (second w CANCELS that ư: huaww→huaw, luuww→luuw).
+    /// A standalone-w ư is excluded: a later w must breve/horn the leftover
+    /// vowel (waw→ưă, wuw→ưư) instead of consuming w at a distance (waw→wa).
+    @inline(__always)
+    private func uaUuPredecessorAllowsRetarget(_ pred: Int) -> Bool {
+        let m = letters[pred].mark
+        return m == .none || (m == .horn && !letterCreatedByW(pred))
+    }
+
     @inline(__always)
     private func hasLowercaseBefore(_ at: Int) -> Bool {
         for i in 0..<at where raw[i] >= UInt8(ascii: "a") && raw[i] <= UInt8(ascii: "z") {
@@ -1597,24 +1607,27 @@ public struct TelexEngine {
             // "ua" nucleus: w horns the u (→ ưa: mưa, chưa, nữa), not breve the a
             // — "uă" is not a valid Vietnamese nucleus. So an unmarked 'a' target
             // whose immediate predecessor is a REAL 'u' vowel retargets to that u.
-            // If that u is already horned, the same retarget lets a second w
+            // If that typed u is already horned, the same retarget lets a second w
             // CANCEL ư (huaw→hưa, huaww→huaw) instead of breving the leftover a
-            // (hưă). Excludes the "qu" glide ("quatw"→quăt) and "oa" (→ oă:
+            // (hưă). A standalone-w ư is not a typed u — leave it so waw→ưă.
+            // Excludes the "qu" glide ("quatw"→quăt) and "oa" (→ oă:
             // hoăc), where breve on a is correct. Makes marks order-free:
             // "nuawx" and "nuwax" both give "nữa".
             if tIdx >= 1,
                letters[tIdx].base == UInt8(ascii: "a"), letters[tIdx].mark == .none,
                letters[tIdx - 1].base == UInt8(ascii: "u"),
+               uaUuPredecessorAllowsRetarget(tIdx - 1),
                !(tIdx >= 2 && letters[tIdx - 2].base == UInt8(ascii: "q")) {
                 tIdx -= 1
             }
             // "uu" nucleus: w horns the FIRST u (→ ưu: lưu, cứu, hưu) — "uư" is not
             // a valid Vietnamese nucleus, so "luuw"→lưu / "cuuws"→cứu instead of
             // the useless "luư". A second w cancels the same way ("luuww"→luuw).
-            // Same "qu" exclusion ("quuw" keeps the glide u untouched).
+            // Same standalone-w guard (wuw→ưư) and "qu" exclusion.
             if tIdx >= 1,
                letters[tIdx].base == UInt8(ascii: "u"), letters[tIdx].mark == .none,
                letters[tIdx - 1].base == UInt8(ascii: "u"),
+               uaUuPredecessorAllowsRetarget(tIdx - 1),
                !(tIdx >= 2 && letters[tIdx - 2].base == UInt8(ascii: "q")) {
                 tIdx -= 1
             }

--- a/TelexCore/Sources/TelexCore/TelexEngine.swift
+++ b/TelexCore/Sources/TelexCore/TelexEngine.swift
@@ -1862,12 +1862,14 @@ public struct TelexEngine {
                 if Self.vniMarkAccepts(base: letters[k].base, mark: mark) {
                     // "uu" nucleus: 7 (horn) đặt lên chữ u ĐẦU (→ ưu: lưu, cứu, hưu)
                     // — "uư" không phải nhân âm tiếng Việt. Cùng luật với w-handler
-                    // Telex ("luuw"→lưu), cùng ngoại lệ "qu" (glide giữ nguyên).
-                    // Issue #66 (29/08/2026): VNI "uu7" ra "uư" thay vì "ưu".
+                    // Telex ("luuw"→lưu, "luuww"→luuw): predecessor u may already
+                    // be horned so the second 7 CANCELS that ư ("luu77"→luu7), and
+                    // cancel must use `target` not `k` or the leftover u gets
+                    // horned instead. Cùng ngoại lệ "qu". Issue #66 (29/08/2026).
                     var target = k
                     if mark == .horn, target >= 1,
                        letters[target].base == UInt8(ascii: "u"), letters[target].mark == .none,
-                       letters[target - 1].base == UInt8(ascii: "u"), letters[target - 1].mark == .none,
+                       letters[target - 1].base == UInt8(ascii: "u"),
                        !(target >= 2 && letters[target - 2].base == UInt8(ascii: "q")) {
                         target -= 1
                     }
@@ -1876,8 +1878,8 @@ public struct TelexEngine {
                         rawLetter[at] = target
                         return
                     }
-                    if letters[k].mark == mark {        // re-applied → cancel, literal digit
-                        letters[k].mark = .none
+                    if letters[target].mark == mark {   // re-applied → cancel, literal digit
+                        letters[target].mark = .none
                         pCancelled = true
                         appendLetter(base: key, mark: .none, upper: false)
                         rawLetter[at] = pCount - 1

--- a/TelexCore/Sources/TelexCore/TelexEngine.swift
+++ b/TelexCore/Sources/TelexCore/TelexEngine.swift
@@ -1596,23 +1596,25 @@ public struct TelexEngine {
             }
             // "ua" nucleus: w horns the u (→ ưa: mưa, chưa, nữa), not breve the a
             // — "uă" is not a valid Vietnamese nucleus. So an unmarked 'a' target
-            // whose immediate predecessor is a REAL, unmarked 'u' vowel retargets
-            // to that u. Excludes the "qu" glide ("quatw"→quăt) and "oa" (→ oă:
+            // whose immediate predecessor is a REAL 'u' vowel retargets to that u.
+            // If that u is already horned, the same retarget lets a second w
+            // CANCEL ư (huaw→hưa, huaww→huaw) instead of breving the leftover a
+            // (hưă). Excludes the "qu" glide ("quatw"→quăt) and "oa" (→ oă:
             // hoăc), where breve on a is correct. Makes marks order-free:
             // "nuawx" and "nuwax" both give "nữa".
             if tIdx >= 1,
                letters[tIdx].base == UInt8(ascii: "a"), letters[tIdx].mark == .none,
-               letters[tIdx - 1].base == UInt8(ascii: "u"), letters[tIdx - 1].mark == .none,
+               letters[tIdx - 1].base == UInt8(ascii: "u"),
                !(tIdx >= 2 && letters[tIdx - 2].base == UInt8(ascii: "q")) {
                 tIdx -= 1
             }
             // "uu" nucleus: w horns the FIRST u (→ ưu: lưu, cứu, hưu) — "uư" is not
             // a valid Vietnamese nucleus, so "luuw"→lưu / "cuuws"→cứu instead of
-            // the useless "luư". Same shape as the "ua" retarget above, and the
-            // same "qu" exclusion ("quuw" keeps the glide u untouched).
+            // the useless "luư". A second w cancels the same way ("luuww"→luuw).
+            // Same "qu" exclusion ("quuw" keeps the glide u untouched).
             if tIdx >= 1,
                letters[tIdx].base == UInt8(ascii: "u"), letters[tIdx].mark == .none,
-               letters[tIdx - 1].base == UInt8(ascii: "u"), letters[tIdx - 1].mark == .none,
+               letters[tIdx - 1].base == UInt8(ascii: "u"),
                !(tIdx >= 2 && letters[tIdx - 2].base == UInt8(ascii: "q")) {
                 tIdx -= 1
             }

--- a/TelexCore/Tests/TelexCoreTests/BackspaceTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/BackspaceTests.swift
@@ -81,7 +81,8 @@ final class BackspaceTests: XCTestCase {
 
     func testBackspaceEveryPositionKeepsRawInvariant() {
         let words = ["dduwowngf", "nguwowif", "truowngf", "vieejt", "tieengs",
-                     "hoas", "nuawx", "quocs", "ddaay", "nghieeng", "chuyeenr", "khoo"]
+                     "hoas", "nuawx", "quocs", "ddaay", "nghieeng", "chuyeenr", "khoo",
+                     "huaww", "huawwei", "luuww"]
         for w in words {
             // Backspace all the way down, checking the invariant after every delete.
             var e = TelexEngine()

--- a/TelexCore/Tests/TelexCoreTests/BackspaceTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/BackspaceTests.swift
@@ -82,7 +82,7 @@ final class BackspaceTests: XCTestCase {
     func testBackspaceEveryPositionKeepsRawInvariant() {
         let words = ["dduwowngf", "nguwowif", "truowngf", "vieejt", "tieengs",
                      "hoas", "nuawx", "quocs", "ddaay", "nghieeng", "chuyeenr", "khoo",
-                     "huaww", "huawwei", "luuww"]
+                     "huaww", "huawwei", "luuww", "waw", "waww", "thwaw"]
         for w in words {
             // Backspace all the way down, checking the invariant after every delete.
             var e = TelexEngine()

--- a/TelexCore/Tests/TelexCoreTests/EdgeCaseTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/EdgeCaseTests.swift
@@ -68,6 +68,7 @@ final class EdgeCaseTests: XCTestCase {
         XCTAssertEqual(compose("uww"), "uw")     // ư then cancel → literal u + w
         XCTAssertEqual(compose("aww"), "aw")     // ă then cancel → literal a + w (parity)
         XCTAssertEqual(compose("huaww"), "huaw") // ua-horn cancel, not hưă
+        XCTAssertEqual(compose("waw"), "ưă")     // standalone-w ư is not retargeted
         // After the cancel the word stays literal (English gesture).
         XCTAssertEqual(compose("owws"), "ows")   // trailing s literal, not a tone
     }

--- a/TelexCore/Tests/TelexCoreTests/EdgeCaseTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/EdgeCaseTests.swift
@@ -67,6 +67,7 @@ final class EdgeCaseTests: XCTestCase {
         XCTAssertEqual(compose("oww"), "ow")     // ơ then cancel → literal o + w
         XCTAssertEqual(compose("uww"), "uw")     // ư then cancel → literal u + w
         XCTAssertEqual(compose("aww"), "aw")     // ă then cancel → literal a + w (parity)
+        XCTAssertEqual(compose("huaww"), "huaw") // ua-horn cancel, not hưă
         // After the cancel the word stays literal (English gesture).
         XCTAssertEqual(compose("owws"), "ows")   // trailing s literal, not a tone
     }

--- a/TelexCore/Tests/TelexCoreTests/EngineTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/EngineTests.swift
@@ -518,6 +518,43 @@ final class EngineGoldenTests: XCTestCase {
         // "qu" glide keeps breve on a (the u belongs to the onset, not retargeted).
         XCTAssertEqual(compose("quawt"), "quăt")   // w adjacent to a -> breve, not horn-u
         XCTAssertEqual(compose("quaw"), "quă")
+
+        // Cancel mirror of the ua retarget (Laban/UniKey parity): the leftover
+        // unmarked a is NOT a new breve target. One more w undoes ư and types
+        // literal w, so "huawei" is visible while typing — not "hưă" until space.
+        XCTAssertEqual(compose("huaw"), "hưa")
+        XCTAssertEqual(compose("huaww"), "huaw")
+        XCTAssertEqual(compose("huawwe"), "huawe")
+        XCTAssertEqual(compose("huawwei"), "huawei")
+        XCTAssertEqual(commit("huawwei"), "huawei")
+        XCTAssertEqual(commit("huaww"), "huaw")     // trailing cancel keeps the screen
+        XCTAssertEqual(compose("muaww"), "muaw")
+        XCTAssertEqual(compose("chuaww"), "chuaw")
+        XCTAssertEqual(composeSimple("huaww"), "huaw")
+        XCTAssertEqual(composeFree("huaww"), "huaw")
+        XCTAssertEqual(composeSpell("huaww"), "huaw")
+        // "oa"/"qu" still breve-then-cancel on a (the retarget never applied).
+        XCTAssertEqual(compose("hoaww"), "hoaw")
+        XCTAssertEqual(compose("quaww"), "quaw")
+        // Same cancel shape on the "uu" nucleus: lưu + w → luuw, not lưư.
+        XCTAssertEqual(compose("luuw"), "lưu")
+        XCTAssertEqual(compose("luuww"), "luuw")
+        XCTAssertEqual(commit("luuww"), "luuw")
+        XCTAssertEqual(composeFree("luuww"), "luuw")
+    }
+
+    /// ⌫ after the ua-horn cancel must drop the literal w (back to hưa), never
+    /// desync into extra w's on screen ("huawww").
+    func testUaHornCancelBackspace() {
+        var e = TelexEngine()
+        for ch in "huaww" { _ = e.feed(ch) }
+        XCTAssertEqual(e.composed, "huaw")
+        _ = e.backspace()
+        XCTAssertEqual(e.composed, "hưa")
+        XCTAssertEqual(compose(e.rawKeystrokes), e.composed)
+        _ = e.backspace()
+        XCTAssertEqual(e.composed, "hư")           // drop displayed 'a'; leftover huw → hư
+        XCTAssertEqual(compose(e.rawKeystrokes), e.composed)
     }
 
     // Simple Telex: a standalone w is ALWAYS literal — type `uw` for ư.
@@ -876,6 +913,8 @@ final class EngineGoldenTests: XCTestCase {
             ("ooo", "oo"),
             ("ddd", "dd"),
             ("aww", "aw"),
+            ("huaww", "huaw"), // ua-horn cancel, not hưă
+            ("luuww", "luuw"),
             ("ass", "as"),   // double sắc cancels, literal s
             ("aff", "af"),
             ("arr", "ar"),

--- a/TelexCore/Tests/TelexCoreTests/EngineTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/EngineTests.swift
@@ -542,14 +542,14 @@ final class EngineGoldenTests: XCTestCase {
         XCTAssertEqual(commit("luuww"), "luuw")
         XCTAssertEqual(composeFree("luuww"), "luuw")
 
-        // Retarget onto a standalone-w ư: cancel reverts the LETTER (w→ư, ww→w)
-        // instead of appending, so the second w is consumed at a distance.
-        XCTAssertEqual(compose("waw"), "wa")
-        XCTAssertEqual(compose("waww"), "waw")
-        XCTAssertEqual(compose("thwaw"), "thwa")
-        XCTAssertEqual(compose("wuw"), "wu")
-        // Tone before the cancel still renders; the literal w is a coda so the
-        // tone re-homes onto a (same as awsw→áw — pre-existing, now pinned).
+        // Standalone-w ư is not a typed-u retarget: the next w breves/horns the
+        // leftover vowel (classic Telex), instead of consuming w at a distance.
+        XCTAssertEqual(compose("waw"), "ưă")
+        XCTAssertEqual(compose("waww"), "ưaw")      // ă-cancel, same as aww→aw
+        XCTAssertEqual(compose("thwaw"), "thưă")
+        XCTAssertEqual(compose("wuw"), "ưư")
+        // Typed-u cancel still works with a tone already on the syllable; the
+        // literal w is a coda so the tone re-homes onto a (same as awsw→áw).
         XCTAssertEqual(compose("nuawxw"), "nuãw")
     }
 
@@ -565,6 +565,18 @@ final class EngineGoldenTests: XCTestCase {
         _ = e.backspace()
         XCTAssertEqual(e.composed, "hư")           // drop displayed 'a'; leftover huw → hư
         XCTAssertEqual(compose(e.rawKeystrokes), e.composed)
+    }
+
+    /// Standalone-w ư + a + w must stay ưă (not consume w). ⌫ drops the whole ă
+    /// (a + the breve w), leaving ư — same provenance as `aw` → ă → ⌫.
+    func testStandaloneWUaKeepsBreveBackspace() {
+        var e = TelexEngine()
+        for ch in "waw" { _ = e.feed(ch) }
+        XCTAssertEqual(e.composed, "ưă")
+        _ = e.backspace()
+        XCTAssertEqual(e.composed, "ư")
+        XCTAssertEqual(compose(e.rawKeystrokes), e.composed)
+        XCTAssertEqual(e.rawKeystrokes, "w")
     }
 
     // Simple Telex: a standalone w is ALWAYS literal — type `uw` for ư.
@@ -925,6 +937,8 @@ final class EngineGoldenTests: XCTestCase {
             ("aww", "aw"),
             ("huaww", "huaw"), // ua-horn cancel, not hưă
             ("luuww", "luuw"),
+            ("waw", "ưă"),    // standalone-w ư stays; w breves a
+            ("waww", "ưaw"),
             ("ass", "as"),   // double sắc cancels, literal s
             ("aff", "af"),
             ("arr", "ar"),

--- a/TelexCore/Tests/TelexCoreTests/EngineTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/EngineTests.swift
@@ -541,6 +541,16 @@ final class EngineGoldenTests: XCTestCase {
         XCTAssertEqual(compose("luuww"), "luuw")
         XCTAssertEqual(commit("luuww"), "luuw")
         XCTAssertEqual(composeFree("luuww"), "luuw")
+
+        // Retarget onto a standalone-w ư: cancel reverts the LETTER (w→ư, ww→w)
+        // instead of appending, so the second w is consumed at a distance.
+        XCTAssertEqual(compose("waw"), "wa")
+        XCTAssertEqual(compose("waww"), "waw")
+        XCTAssertEqual(compose("thwaw"), "thwa")
+        XCTAssertEqual(compose("wuw"), "wu")
+        // Tone before the cancel still renders; the literal w is a coda so the
+        // tone re-homes onto a (same as awsw→áw — pre-existing, now pinned).
+        XCTAssertEqual(compose("nuawxw"), "nuãw")
     }
 
     /// ⌫ after the ua-horn cancel must drop the literal w (back to hưa), never
@@ -1123,5 +1133,19 @@ final class BracketVowelTests: XCTestCase {
         }
         XCTAssertEqual(e.composed, "th")
         XCTAssertEqual(e.rawKeystrokes, "th")
+    }
+
+    /// ua-retarget cancel also hits a `]`-typed ư (stored as u+horn). That ư was
+    /// not created by w, so cancel strips the horn and appends w — same gesture
+    /// as `huaww`, not a new breve on the leftover a.
+    func testUaCancelOnBracketHorn() {
+        var e = TelexEngine(); e.bracketVowels = true
+        for ch in "h]aw" { _ = e.feed(ch) }
+        XCTAssertEqual(e.composed, "huaw")
+        XCTAssertEqual(e.rawKeystrokes, "h]aw")
+        XCTAssertEqual(e.commitText(autoRestore: true), "huaw")
+        var f = TelexEngine(); f.bracketVowels = true
+        for ch in "]aw" { _ = f.feed(ch) }
+        XCTAssertEqual(f.composed, "uaw")
     }
 }

--- a/TelexCore/Tests/TelexCoreTests/ModeMatrixTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/ModeMatrixTests.swift
@@ -31,7 +31,7 @@ final class ModeMatrixTests: XCTestCase {
         "cw", "kw", "uw", "cuw", "thw", "ngw", "windows", "ew", "giw",
         "hoas", "khoer", "thuys", "hoef", "muaf", "mias", "toans", "nguowif",
         "truowngf", "dduowcj", "nuawx", "nuwax", "ddaay", "tieengs", "vieejt",
-        "huaww", "huawwei", "luuww",
+        "huaww", "huawwei", "luuww", "waw", "waww",
     ]
 
     // freeMarking flip: rebuild path — must equal from-start for every flip point.

--- a/TelexCore/Tests/TelexCoreTests/ModeMatrixTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/ModeMatrixTests.swift
@@ -31,6 +31,7 @@ final class ModeMatrixTests: XCTestCase {
         "cw", "kw", "uw", "cuw", "thw", "ngw", "windows", "ew", "giw",
         "hoas", "khoer", "thuys", "hoef", "muaf", "mias", "toans", "nguowif",
         "truowngf", "dduowcj", "nuawx", "nuwax", "ddaay", "tieengs", "vieejt",
+        "huaww", "huawwei", "luuww",
     ]
 
     // freeMarking flip: rebuild path — must equal from-start for every flip point.

--- a/TelexCore/Tests/TelexCoreTests/ScreenSimulationTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/ScreenSimulationTests.swift
@@ -88,6 +88,7 @@ final class ScreenSimulationTests: XCTestCase {
         "thuowr", "huow", "quowr", "quown", "quowrn",
         // ua nucleus retarget
         "nuawx", "nuwax", "muaw", "chuaw", "buawx", "tuawj",
+        "huaww", "huawwei", "luuww",
         // qu + a + w
         "quawt", "quaw", "hoaw", "hoawcj",
         // tones on all vowels
@@ -150,7 +151,8 @@ final class ScreenSimulationTests: XCTestCase {
     // Backspace at every position of a long word, then continue typing — the screen
     // must track the engine through the destructive edits.
     func testScreenTracksBackspaceThenRetype() {
-        let words = ["dduwowngf", "nguwowif", "truowngf", "vieejt", "khoo", "tieengs"]
+        let words = ["dduwowngf", "nguwowif", "truowngf", "vieejt", "khoo", "tieengs",
+                     "huaww", "huawwei"]
         for w in words {
             for cut in 1...w.count {
                 var ops: [(Character?, Bool)] = w.map { ($0, false) }

--- a/TelexCore/Tests/TelexCoreTests/ScreenSimulationTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/ScreenSimulationTests.swift
@@ -88,7 +88,7 @@ final class ScreenSimulationTests: XCTestCase {
         "thuowr", "huow", "quowr", "quown", "quowrn",
         // ua nucleus retarget
         "nuawx", "nuwax", "muaw", "chuaw", "buawx", "tuawj",
-        "huaww", "huawwei", "luuww",
+        "huaww", "huawwei", "luuww", "waw", "waww", "thwaw",
         // qu + a + w
         "quawt", "quaw", "hoaw", "hoawcj",
         // tones on all vowels
@@ -152,7 +152,7 @@ final class ScreenSimulationTests: XCTestCase {
     // must track the engine through the destructive edits.
     func testScreenTracksBackspaceThenRetype() {
         let words = ["dduwowngf", "nguwowif", "truowngf", "vieejt", "khoo", "tieengs",
-                     "huaww", "huawwei"]
+                     "huaww", "huawwei", "waww"]
         for w in words {
             for cut in 1...w.count {
                 var ops: [(Character?, Bool)] = w.map { ($0, false) }

--- a/TelexCore/Tests/TelexCoreTests/VNIHornUURetargetTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/VNIHornUURetargetTests.swift
@@ -27,5 +27,16 @@ final class VNIHornUURetargetTests: XCTestCase {
     func testQuGlideExcluded() {
         // "qu" glide: chữ u sau q không phải target horn-retarget (giống Telex).
         XCTAssertEqual(vni("quu7"), "quư")
+        XCTAssertEqual(vni("quu77"), "quu7")   // cancel the last-u horn, not retarget
+    }
+
+    /// Second 7 undoes ư on the first u (Telex `luuww`→luuw), instead of horning
+    /// the leftover u (`lưư`). Cancel must follow the retargeted `target`.
+    func testSecondHornCancelsFirstU() {
+        XCTAssertEqual(vni("luu77"), "luu7")
+        XCTAssertEqual(vni("uu77"), "uu7")
+        XCTAssertEqual(vni("cuu775"), "cuu75")  // further digits stay literal
+        XCTAssertEqual(vni("tu77"), "tu7")      // single u: cancel still on that u
+        XCTAssertEqual(vni("hua77"), "hua7")    // 7 never targets a; second 7 cancels ư
     }
 }

--- a/TelexCore/Tests/TelexCoreTests/VNITests.swift
+++ b/TelexCore/Tests/TelexCoreTests/VNITests.swift
@@ -130,6 +130,8 @@ final class VNITests: XCTestCase {
         // Same mark digit twice cancels → mark gone, digit literal.
         XCTAssertEqual(vni("a66"), "a6")
         XCTAssertEqual(vni("a88"), "a8")
+        XCTAssertEqual(vni("u77"), "u7")
+        XCTAssertEqual(vni("o77"), "o7")
         XCTAssertEqual(vni("d99"), "d9")
         // Lone 0 with no tone is a literal digit.
         XCTAssertEqual(vni("a0"), "a0")


### PR DESCRIPTION
## Thay đổi gì

Gõ `huawei` kiểu Laban: `huaw` → **hưa**, `huaww` → **huaw** (w thứ hai bỏ dấu ư). Trước đây w thứ hai đánh dấu ă lên a còn lại → **hưă**, và ⌫ dễ lệch thành `huawww`. Sau fix, gõ thêm một phát là bỏ dấu ngay trên màn hình, không cần cách rồi chờ auto-restore.

## Loại thay đổi

- [ ] Rule cơ chế gõ (`typing-modes.yml`)
- [x] Engine / validator (`TelexCore/`)
- [ ] App: routing per-app, IMKit, CGEventTap, Settings UI (`App/Sources/`)
- [ ] Tài liệu (`docs/`, `README.md`, `BAO-LOI.md`)
- [ ] Khác:

## Đã test

- [x] `cd TelexCore && swift test` xanh (262 tests, 0 fail; `SUITE transform: 400/400`, `restore_raw: 7135/7216`)
- [x] Có golden test cho hành vi mới trong `EngineTests.swift` (bắt buộc khi sửa engine)
- [x] `swift test -c release --filter 'Benchmark|ZeroAllocation'` xanh — hot path không cấp phát heap
- [ ] Đã cài lên máy thật (`Scripts/dev-install.sh`) và gõ thử trong app bị ảnh hưởng, theo [`docs/checklist.md`](https://github.com/ptrinh/viettelex/blob/main/docs/checklist.md)

Máy đã test: engine-only trên macOS 15 (darwin 24.6), Xcode toolchain — chưa `dev-install` lên input method thật.

## Ghi chú cho reviewer

Nguyên nhân: retarget vần `ua`/`uu` chỉ chạy khi chữ u *chưa* có horn. `huaw` horns u → hưa; `w` tiếp theo thấy `a` trần nên breve thành hưă, thay vì đi vào nhánh cancel sẵn có (`aww`/`uww`).

Sửa: bỏ điều kiện `predecessor.mark == .none`. u đã horn thì w thứ hai retarget về u và cancel → `huaw`. Cùng hình với vần `uu` (`luuww`→`luuw`, không `lưư`). Ngoại lệ `qu`/`oa` giữ nguyên (`quaww`→`quaw`, `hoaww`→`hoaw`).

Sau cancel, `pCancelled` đóng mọi dấu tiếp theo (cùng luật `aww`/`themee`) nên `huawwei` hiện **huawei** khi đang gõ. ⌫ từ `huaw` về `hưa` — provenance một glyph, không thừa `w`.

Ngoài phạm vi: VNI digit 7/8 (gõ `huawei` bằng Telex `w`, không phải VNI).

Made with [Cursor](https://cursor.com)