### PR TITLE
fix(engine): gõ lít không bị sửa thành list

### DIFF
--- a/TelexCore/Sources/GenEnglish/main.swift
+++ b/TelexCore/Sources/GenEnglish/main.swift
@@ -83,6 +83,7 @@ let protected: Set<String> = [
     // của một từ Việt phổ biến.
     "ướt",  // worst (ướt át)
     "lẩu",  // laura (nồi lẩu)
+    "lít",  // list  (lít nước — phiên âm mượn litre; 2026-09-10)
 ]
 
 /// Rác viết tắt trong corpus web (không phải từ tiếng Anh thật) — vào bảng sẽ

--- a/TelexCore/Sources/TelexCore/EnglishCollisions.swift
+++ b/TelexCore/Sources/TelexCore/EnglishCollisions.swift
@@ -74,7 +74,7 @@ enum EnglishCollisions {
     jeffrey jerry jesse jessica jesus jewellery kansas karma
     kerry kiss kissing kits laboratory larger larry last
     law laws lesbians less lesser lesson lessons libraries
-    library lies life list listings lists literature loans
+    library lies life listings lists literature loans
     lose loss losses madagascar madness major manufacturer maps
     marks marriage married marriott mary mask mass massage
     massive mattress meets melissa mens merry mess message

--- a/TelexCore/Tests/TelexCoreTests/ContextEnglishTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/ContextEnglishTests.swift
@@ -162,6 +162,11 @@ final class ContextEnglishTests: XCTestCase {
         // "loans" is already an unconditional English-collision word → always English.
         XCTAssertEqual(sentence("loans", context: true), "loans")
         XCTAssertEqual(sentence("she loans", context: true), "she loans")
+        // list→lít: Vietnamese loanword (litre) when alone; English only inside
+        // an English run (stays on the context whitelist, off the collision table).
+        XCTAssertEqual(sentence("list", context: true), "lít")
+        XCTAssertEqual(sentence("she list", context: true), "she list")
+        XCTAssertEqual(sentence("toi list nuoc", context: true), "toi lít nuoc")
     }
 
     // Vietnamese loanwords (email/app/web) are NEUTRAL: they don't open an English run,

--- a/TelexCore/Tests/TelexCoreTests/EngineTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/EngineTests.swift
@@ -201,6 +201,8 @@ final class EngineGoldenTests: XCTestCase {
         XCTAssertEqual(commitFree("hair"), "hải")
         XCTAssertEqual(commitFree("lens"), "lén")
         XCTAssertEqual(commitFree("hits"), "hít")
+        XCTAssertEqual(commitFree("list"), "lít")   // phiên âm mượn litre; list là free-marking
+        XCTAssertEqual(commitFree("lits"), "lít")   // thanh cuối từ — đường còn lại
         XCTAssertEqual(commitFree("sets"), "sét")
         XCTAssertEqual(commitFree("boots"), "bốt")
         XCTAssertEqual(commitFree("lots"), "lót")

--- a/TelexCore/Tests/TelexCoreTests/GonhanhLearningsTests.swift
+++ b/TelexCore/Tests/TelexCoreTests/GonhanhLearningsTests.swift
@@ -21,10 +21,14 @@ final class EnglishCollisionTests: XCTestCase {
         // this→thí, is→í, of→ò, if→ì, us→ú, has→há, days→dáy — protect list);
         // this golden keeps only the words whose spelling is NOT a natural
         // telex order, which stay English.
-        for w in ["see", "or", "must", "last", "list", "most", "does", "those",
+        for w in ["see", "or", "must", "last", "most", "does", "those",
                   "these", "there", "here", "test", "now"] where w != "now" {
             XCTAssertEqual(commit(w), w, "English '\(w)' must survive")
         }
+        // list→lít: từ Việt phiên âm mượn (lít nước). Free-marking li+s+t
+        // trùng chính tả English; tiếng Việt thắng (protect list), giống hits→hít.
+        XCTAssertEqual(commit("list"), "lít")
+        XCTAssertEqual(commit("lits"), "lít")
         XCTAssertEqual(commit("did"), "đi")
         XCTAssertEqual(commit("his"), "hí")
         XCTAssertEqual(commit("this"), "thí")
@@ -92,6 +96,7 @@ final class EnglishCollisionTests: XCTestCase {
         XCTAssertEqual(commit("its"), "ít")
         XCTAssertEqual(commit("as"), "á")
         XCTAssertEqual(commit("low"), "lơ")
+        XCTAssertEqual(commit("list"), "lít")
     }
 
     func testTeencodeSurvivesInSimpleTelex() {
@@ -164,7 +169,8 @@ final class EnglishCollisionTests: XCTestCase {
         for banned in ["sex", "teen", "been", "own", "car", "too", "its", "as",
                        "low", "now", "how", "room", "box", "air", "bar", "beer",
                        "bus", "lee", "max", "moon", "seen", "sir", "six", "tax", "ups",
-                       "his", "this", "is", "of", "if", "us", "has", "thus", "queen"] {
+                       "his", "this", "is", "of", "if", "us", "has", "thus", "queen",
+                       "list"] {
             XCTAssertFalse(EnglishCollisions.words.contains(banned), "protected '\(banned)' leaked into the table")
         }
         // web-corpus junk that would eat Vietnamese typing (sw = sư)


### PR DESCRIPTION
## Thay đổi gì

Gõ `lít` (cả `list` lẫn `lits`) bị bảng collision khôi phục thành **list**. `lít` là từ Việt thật (phiên âm mượn *litre*, “một lít nước”) nên tiếng Việt thắng, giống `hits`→`hít` / `tits`→`tít` / `its`→`ít`.

Sau từ tiếng Anh (`the list`, `she list`) vẫn ra `list` — `list` còn trên whitelist ngữ cảnh, chỉ rời bảng collision.

## Loại thay đổi

- [ ] Rule cơ chế gõ (`typing-modes.yml`)
- [x] Engine / validator (`TelexCore/`)
- [ ] App: routing per-app, IMKit, CGEventTap, Settings UI (`App/Sources/`)
- [ ] Tài liệu (`docs/`, `README.md`, `BAO-LOI.md`)
- [ ] Khác:

## Đã test

- [x] `cd TelexCore && swift test` xanh (265 tests, 0 fail; `SUITE transform: 400/400`, `restore_raw: 7135/7216`, context 632/1047)
- [x] Có golden test cho hành vi mới trong `EngineTests.swift` (bắt buộc khi sửa engine)
- [ ] `swift test -c release --filter 'Benchmark|ZeroAllocation'` xanh — hot path không cấp phát heap
- [ ] Đã cài lên máy thật (`Scripts/dev-install.sh`) và gõ thử trong app bị ảnh hưởng, theo [`docs/checklist.md`](https://github.com/ptrinh/viettelex/blob/main/docs/checklist.md)

Máy đã test: chỉ unit test TelexCore (không đổi hot path, chỉ protect-list + gỡ 1 từ khỏi bảng collision)

## Ghi chú cho reviewer

Đánh đổi: gõ `list` đứng một mình / sau tiếng Việt ra **lít**. Muốn chữ English `list` ở đầu câu thì cần mạch tiếng Anh trước đó (mặc định app đã bật context) hoặc escape. Cùng chính sách protect-list 2026-07-23.


Made with [Cursor](https://cursor.com)